### PR TITLE
dev: remove build caching & redundant go install in dev docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ test-commit:
 
 #build-tptdev: @ Build tptdev binary
 build-tptdev:
-	go build -a -o bin/tptdev cmd/tptdev/main.go
+	go build -o bin/tptdev cmd/tptdev/main.go
 
 #build-tptctl: @ Build tptctl binary
 build-tptctl:
-	go build -a -o bin/tptctl cmd/tptctl/main.go
+	go build -o bin/tptctl cmd/tptctl/main.go
 
 release:
 ifndef RELEASE_VERSION

--- a/cmd/rest-api/image/Dockerfile-dev
+++ b/cmd/rest-api/image/Dockerfile-dev
@@ -1,16 +1,14 @@
 FROM golang:1.19-alpine
 
+RUN go install github.com/cosmtrek/air@latest
+
 RUN mkdir /threeport
-ADD . /threeport
 WORKDIR /threeport
 
-RUN apk add --no-cache --update \
-    build-base
-RUN go install github.com/cosmtrek/air@latest
-RUN go mod download
+# "go install" is not needed here because we mount source code from host
 
 CMD ["air", \
     "-c", "/threeport/cmd/rest-api/image/air.toml", \
-    "-build.cmd", "go build -a -o bin/threeport-rest-api cmd/rest-api/main.go", \
+    "-build.cmd", "go build -o bin/threeport-rest-api cmd/rest-api/main.go", \
     "-build.bin", "./bin/threeport-rest-api"]
 

--- a/cmd/workload-controller/image/Dockerfile-dev
+++ b/cmd/workload-controller/image/Dockerfile-dev
@@ -1,16 +1,14 @@
 FROM golang:1.19-alpine
 
+RUN go install github.com/cosmtrek/air@latest
+
 RUN mkdir /threeport
-ADD . /threeport
 WORKDIR /threeport
 
-RUN apk add --no-cache --update \
-    build-base
-RUN go install github.com/cosmtrek/air@latest
-RUN go mod download
+# "go install" is not needed here because we mount source code from host
 
 CMD ["air", \
     "-c", "/threeport/cmd/workload-controller/image/air.toml", \
-    "-build.cmd", "go build -a -o bin/threeport-workload-controller cmd/workload-controller/main_gen.go", \
+    "-build.cmd", "go build -o bin/threeport-workload-controller cmd/workload-controller/main_gen.go", \
     "-build.bin", "./bin/threeport-workload-controller"]
 


### PR DESCRIPTION
Minor Docker & makefile improvements to speed up build times.