### PR TITLE
ci: add base branch check for 0.2 features (#49)

### DIFF
--- a/.github/workflows/base-branch.yml
+++ b/.github/workflows/base-branch.yml
@@ -1,0 +1,22 @@
+name: Check Base Branch
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  base-branch-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check Base Branch
+      run: |
+        if [[ "${GITHUB_BASE_REF}" != "0.2" ]]; then
+          echo "Error: By default the pull request should be targeting the '0.2' branch but targets '${GITHUB_BASE_REF}' instead."
+          echo "You can ignore this error if you are adding a bug fix to an earlier minor version release"
+          exit 1
+        fi
+

--- a/.github/workflows/commit-messages.yml
+++ b/.github/workflows/commit-messages.yml
@@ -1,4 +1,4 @@
-name: Check
+name: Check Commit Messages
 
 on:
   push:


### PR DESCRIPTION
This PR adds a check for the base branch to main.  We have a CI check on 0.2 branch that checks the base branch.  However, if we accidentally branch off main for a feature that is intended for the 0.2 branch, the check never happens.