### PR TITLE
fix: get AWS configs from threeport config for control plane deletion

### DIFF
--- a/cmd/tptctl/cmd/config_get_instances.go
+++ b/cmd/tptctl/cmd/config_get_instances.go
@@ -29,11 +29,20 @@ var ConfigGetInstancesCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		// check to see if current instance is set
+		if threeportConfig.CurrentInstance == "" {
+			cli.Warning("current instance is not set - set it with 'tptctl config current-instance -i <instance name>'")
+		}
+
 		// output table of results
 		writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-		fmt.Fprintln(writer, "NAME\t PROVIDER")
+		fmt.Fprintln(writer, "NAME\t PROVIDER\t CURRENT INSTANCE")
 		for _, instance := range threeportConfig.Instances {
-			fmt.Fprintln(writer, instance.Name, "\t", instance.Provider)
+			currentInst := false
+			if instance.Name == threeportConfig.CurrentInstance {
+				currentInst = true
+			}
+			fmt.Fprintln(writer, instance.Name, "\t", instance.Provider, "\t", currentInst)
 		}
 		writer.Flush()
 	},

--- a/cmd/tptctl/cmd/delete_control_plane.go
+++ b/cmd/tptctl/cmd/delete_control_plane.go
@@ -33,13 +33,9 @@ func init() {
 		&cliArgs.InstanceName,
 		"name", "n", "", "Required. Name of control plane instance.",
 	)
-	DeleteControlPlaneCmd.Flags().StringVar(
-		&cliArgs.AwsConfigProfile,
-		"aws-config-profile", "default", "The AWS config profile to draw credentials from when using eks provider.",
-	)
-	DeleteControlPlaneCmd.Flags().StringVar(
-		&cliArgs.AwsRegion,
-		"aws-region", "", "AWS region code to install threeport in when using eks provider. If provided, will take precedence over AWS config profile and environment variables.",
+	DeleteControlPlaneCmd.Flags().BoolVar(
+		&cliArgs.AwsConfigEnv,
+		"aws-config-env", false, "Retrieve AWS credentials from environment variables when using eks provider.",
 	)
 	DeleteControlPlaneCmd.MarkFlagRequired("name")
 }

--- a/internal/cli/control_plane.go
+++ b/internal/cli/control_plane.go
@@ -170,7 +170,7 @@ func (a *ControlPlaneCLIArgs) CreateControlPlane() error {
 
 		kubernetesRuntimeInfra = &kubernetesRuntimeInfraKind
 	case v0.KubernetesRuntimeInfraProviderEKS:
-		// create AWS Config
+		// create AWS config
 		awsConf, err := resource.LoadAWSConfig(
 			a.AwsConfigEnv,
 			a.AwsConfigProfile,
@@ -240,7 +240,6 @@ func (a *ControlPlaneCLIArgs) CreateControlPlane() error {
 
 		// update threeport config
 		threeportInstanceConfig.EKSProviderConfig = config.EKSProviderConfig{
-			AwsConfigEnv:     a.AwsConfigEnv,
 			AwsConfigProfile: a.AwsConfigProfile,
 			AwsRegion:        a.AwsRegion,
 			AwsAccountID:     a.CreateProviderAccountID,
@@ -875,11 +874,15 @@ func (a *ControlPlaneCLIArgs) DeleteControlPlane() error {
 		}
 		kubernetesRuntimeInfra = &kubernetesRuntimeInfraKind
 	case v0.KubernetesRuntimeInfraProviderEKS:
-		// create AWS Config
+		// create AWS config
+		// * AwsConfigEnv is always passed in from CLI args as it is not
+		//   persisted in threeport config
+		// * AwsConfigProfile and AwsRegion cannot be passed in through CLI for
+		// deletion opertion as these are stored in threeport config
 		awsConfig, err := resource.LoadAWSConfig(
 			a.AwsConfigEnv,
-			a.AwsConfigProfile,
-			a.AwsRegion,
+			threeportInstanceConfig.EKSProviderConfig.AwsConfigProfile,
+			threeportInstanceConfig.EKSProviderConfig.AwsRegion,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to load AWS configuration with local config: %w", err)

--- a/pkg/config/v0/config.go
+++ b/pkg/config/v0/config.go
@@ -68,7 +68,6 @@ type KubeAPI struct {
 // EKSProviderConfig is the set of provider config information needed to manage
 // EKS clusters on AWs.
 type EKSProviderConfig struct {
-	AwsConfigEnv     bool   `yaml:"AWSConfigEnv"`
 	AwsConfigProfile string `yaml:"AWSConfigProfile"`
 	AwsRegion        string `yaml:"AWSRegion"`
 	AwsAccountID     string `yaml:"AWSAccountID"`
@@ -141,8 +140,8 @@ func (cfg *ThreeportConfig) GetEncryptionKey() (string, error) {
 	return "", errors.New("current instance not found when retrieving encryption key")
 }
 
-// GetThreeportCertificates returns the CA certificate, client certificate, and
-// client private key for a named threeport instance.
+// GetThreeportCertificatesForInstance returns the CA certificate, client
+// certificate, and client private key for a named threeport instance.
 func (cfg *ThreeportConfig) GetThreeportCertificatesForInstance(instanceName string) (string, string, string, error) {
 	// find instance
 	var instance Instance


### PR DESCRIPTION
* The AWS config profile and region are no longer CLI args for `tptctl delete control-plane`.  These values are stored in the threeport config.  Allowing users to define them with flags leaves too much open for interpretation and confusion.  If a user's config profile has been altered locally and needs to be changed, the AWS config env is always available as an escape hatch in this unlikely scenario.
* The AWS config env is no longer stored in threeport config as the use of env vars is a runtime concern and we should not assume the env vars available at create time are available at delete time.  If a user is using environment configs, they need to elect that explicitly with `--aws-config-env` in each case.