### PR TITLE
feat: add bool for AssumeAnyRole policy

### DIFF
--- a/cmd/tptctl/cmd/config_aws_cloud_account.go
+++ b/cmd/tptctl/cmd/config_aws_cloud_account.go
@@ -131,6 +131,7 @@ var ConfigAwsCloudAccountCmd = &cobra.Command{
 			awsAccountId,
 			provider.GetResourceManagerRoleName(requestedControlPlane),
 			*createdAwsAccount.ExternalId,
+			false,
 			true,
 			*awsConf,
 		)

--- a/internal/control-plane/control_plane_instance.go
+++ b/internal/control-plane/control_plane_instance.go
@@ -189,6 +189,7 @@ func controlPlaneInstanceCreated(
 			*callerIdentity.Account,
 			"",
 			"",
+			true,
 			false, // don't attach internal resource manager policy
 			awsConfigResourceManager,
 		)

--- a/internal/provider/eks.go
+++ b/internal/provider/eks.go
@@ -355,7 +355,8 @@ func CreateResourceManagerRole(
 	accountId,
 	principalRoleName,
 	externalId string,
-	attachPolicy bool,
+	attachAssumeAnyRolePolicy bool,
+	attachResourceManagerPolicy bool,
 	awsConfig aws.Config,
 ) (*types.Role, error) {
 	svc := iam.NewFromConfig(awsConfig)
@@ -383,12 +384,14 @@ func CreateResourceManagerRole(
 	}
 
 	// attach assume any role policy
-	if err := AttachPolicy(AssumeAnyRolePolicyDocument, roleName, "assume-any-role", svc); err != nil {
-		return resourceManagerRoleResp.Role, fmt.Errorf("failed to attach policy to role %s: %w", roleName, err)
+	if attachAssumeAnyRolePolicy {
+		if err := AttachPolicy(AssumeAnyRolePolicyDocument, roleName, "assume-any-role", svc); err != nil {
+			return resourceManagerRoleResp.Role, fmt.Errorf("failed to attach policy to role %s: %w", roleName, err)
+		}
 	}
 
 	// attach resource manager policy if requested
-	if attachPolicy {
+	if attachResourceManagerPolicy {
 		if err := AttachPolicy(ResourceManagerPolicyDocument, roleName, "resource-manager", svc); err != nil {
 			return resourceManagerRoleResp.Role, fmt.Errorf("failed to attach policy to role %s: %w", roleName, err)
 		}

--- a/pkg/cli/v0/genesis_control_plane.go
+++ b/pkg/cli/v0/genesis_control_plane.go
@@ -267,6 +267,7 @@ func CreateGenesisControlPlane(customInstaller *threeport.ControlPlaneInstaller)
 			"",
 			"",
 			true,
+			true,
 			awsConfigUser,
 		)
 		if err != nil {


### PR DESCRIPTION
Add a boolean to determine whether the `AssumeAnyRole` policy should be attached. This isn't appropriate for external accounts where the only permissions required are those used to manage resources.