### PR TITLE
fix: bump support services operator memory limit

### DIFF
--- a/pkg/threeport-installer/v0/support_services.go
+++ b/pkg/threeport-installer/v0/support_services.go
@@ -2485,7 +2485,7 @@ func InstallThreeportSupportServicesOperator(
 								"resources": map[string]interface{}{
 									"limits": map[string]interface{}{
 										"cpu":    "500m",
-										"memory": "128Mi",
+										"memory": "256Mi",
 									},
 									"requests": map[string]interface{}{
 										"cpu":    "10m",


### PR DESCRIPTION
The previous limit was causing `OOMKilled` errors in kind environments on mac.