### PR TITLE
fix: allow user to override external role name for AWS cross-account access

### DIFF
--- a/cmd/tptctl/cmd/config_aws_cloud_account.go
+++ b/cmd/tptctl/cmd/config_aws_cloud_account.go
@@ -121,7 +121,7 @@ var ConfigAwsCloudAccountCmd = &cobra.Command{
 			awsAccountId,
 			externalRoleName,
 			*createdAwsAccount.ExternalId,
-			false,
+			true,
 			true,
 			*awsConf,
 		)


### PR DESCRIPTION
Allow a user to specify which `runtime-manager-threeport-$name` role can assume the created role via IAM cross-account authentication.