### PR TITLE
fix: fix dangling ELB when using gloo edge gateway

### DIFF
--- a/internal/gateway/gateway_instance.go
+++ b/internal/gateway/gateway_instance.go
@@ -415,12 +415,6 @@ func confirmGatewayControllerDeployed(
 		return fmt.Errorf("failed to create gloo edge resource: %w", err)
 	}
 
-	// generate support services collection manifest
-	supportServicesCollection, err := createSupportServicesCollection()
-	if err != nil {
-		return fmt.Errorf("failed to create support services collection resource: %w", err)
-	}
-
 	// get infra provider
 	infraProvider, err := client.GetInfraProviderByKubernetesRuntimeInstanceID(r.APIClient, r.APIServer, kubernetesRuntimeInstance.ID)
 	if err != nil {
@@ -454,7 +448,7 @@ func confirmGatewayControllerDeployed(
 	}
 
 	// concatenate gloo edge, support services collection, and cert manager manifests
-	manifest := fmt.Sprintf("---\n%s\n---\n%s\n---\n%s\n", supportServicesCollection, certManager, glooEdge)
+	manifest := fmt.Sprintf("---\n%s\n---\n%s\n", certManager, glooEdge)
 
 	// create gateway controller workload definition
 	workloadDefName := fmt.Sprintf("%s-%s", "gloo-edge", *kubernetesRuntimeInstance.Name)

--- a/internal/gateway/manifests.go
+++ b/internal/gateway/manifests.go
@@ -10,24 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// createSupportServicesCollection creates a support services collection.
-func createSupportServicesCollection() (string, error) {
-	var supportServicesCollection = &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "orchestration.support-services.nukleros.io/v1alpha1",
-			"kind":       "SupportServices",
-			"metadata": map[string]interface{}{
-				"name": "supportservices-sample",
-			},
-			"spec": map[string]interface{}{
-				"tier": "development",
-			},
-		},
-	}
-
-	return unstructuredToYAMLString(supportServicesCollection)
-}
-
 // createGlooEdge creates a gloo edge custom resource.
 func createGlooEdge() (string, error) {
 

--- a/pkg/threeport-installer/v0/components.go
+++ b/pkg/threeport-installer/v0/components.go
@@ -30,6 +30,7 @@ func (cpi *ControlPlaneInstaller) InstallComputeSpaceControlPlaneComponents(
 		return fmt.Errorf("failed to create threeport control plane namespace: %w", err)
 	}
 
+	// threeport agent
 	if err := cpi.InstallThreeportAgent(
 		kubeClient,
 		mapper,
@@ -42,11 +43,6 @@ func (cpi *ControlPlaneInstaller) InstallComputeSpaceControlPlaneComponents(
 	// threeport CRDs
 	if err := InstallThreeportCRDs(kubeClient, mapper); err != nil {
 		return fmt.Errorf("failed to install threeport CRDs: %w", err)
-	}
-
-	// support services operator
-	if err := InstallThreeportSupportServicesOperator(kubeClient, mapper); err != nil {
-		return fmt.Errorf("failed to install support services operator: %w", err)
 	}
 
 	return nil

--- a/pkg/threeport-installer/v0/support_services.go
+++ b/pkg/threeport-installer/v0/support_services.go
@@ -779,11 +779,10 @@ func InstallThreeportCRDs(
 										"description": "SupportServicesSpec defines the desired state of SupportServices.",
 										"properties": map[string]interface{}{
 											"defaultIngressController": map[string]interface{}{
-												"default":     "kong",
-												"description": "(Default: \"kong\") The default ingress for setting TLS certs.  One of: kong | nginx.",
+												"default":     "glooedge",
+												"description": "(Default: \"glooedge\") The default ingress controller for the cluster.",
 												"enum": []interface{}{
-													"kong",
-													"nginx",
+													"glooedge",
 												},
 												"type": "string",
 											},
@@ -2515,6 +2514,20 @@ func InstallThreeportSupportServicesOperator(
 	}
 	if _, err := kube.CreateResource(deployment, kubeClient, *mapper); err != nil {
 		return fmt.Errorf("failed to create deployment: %w", err)
+	}
+
+	var supportServicesCollection = &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "orchestration.support-services.nukleros.io/v1alpha1",
+			"kind":       "SupportServices",
+			"metadata": map[string]interface{}{
+				"name": "threeport-support-services",
+			},
+			"spec": map[string]interface{}{},
+		},
+	}
+	if _, err := kube.CreateResource(supportServicesCollection, kubeClient, *mapper); err != nil {
+		return fmt.Errorf("failed to create support services custom resource: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
The uninstall for the ingress layer was failing to delete the AWS infra. This resulted in failures to remove kubernetes runtime instances. This commit remedies that by deploying the SupportServices collection resource with the support services operator, rather than when the gloo edge component is installed for the workload.