### PR TITLE
fix: add resource manager permissions to terraform controller

### DIFF
--- a/internal/provider/eks.go
+++ b/internal/provider/eks.go
@@ -642,6 +642,7 @@ func IrsaControllerNames() []string {
 		threeport.ThreeportWorkloadControllerName,
 		threeport.ThreeportHelmWorkloadControllerName,
 		threeport.ThreeportControlPlaneControllerName,
+		threeport.ThreeportTerraformControllerName,
 	}
 }
 
@@ -813,6 +814,8 @@ const (
 					"iam:CreatePolicy",
 					"iam:DeletePolicy",
 					"iam:ListPolicies",
+					"iam:ListRolePolicies",
+					"iam:ListInstanceProfilesForRole",
 					"iam:CreatePolicyVersion",
 					"iam:DeletePolicyVersion",
 					"iam:SetDefaultPolicyVersion",

--- a/pkg/cli/v0/genesis_control_plane.go
+++ b/pkg/cli/v0/genesis_control_plane.go
@@ -198,6 +198,7 @@ func CreateGenesisControlPlane(customInstaller *threeport.ControlPlaneInstaller)
 	uninstaller := &Uninstaller{
 		cpi:          cpi,
 		skipTeardown: &cpi.Opts.SkipTeardown,
+		cleanConfig:  util.Ptr(true),
 	}
 
 	// check threeport config to see if it is empty
@@ -710,9 +711,6 @@ func CreateGenesisControlPlane(customInstaller *threeport.ControlPlaneInstaller)
 			return uninstaller.cleanOnCreateError("failed to install threeport API TLS assets", err)
 		}
 	}
-
-	// update uninstaller to clean the threeport config if an error occurs
-	uninstaller.cleanConfig = util.Ptr(true)
 
 	// wait for API server to start running - it is not strictly necessary to
 	// wait for the API before installing the rest of the control plane, however
@@ -1370,6 +1368,7 @@ func (u *Uninstaller) cleanOnCreateError(
 		}
 	}
 
+	// remove control plane from Threeport config
 	if *u.cleanConfig {
 		threeportConfig, _, configErr := config.GetThreeportConfig("")
 		if configErr != nil {

--- a/pkg/threeport-installer/v0/components.go
+++ b/pkg/threeport-installer/v0/components.go
@@ -21,7 +21,9 @@ import (
 	util "github.com/threeport/threeport/pkg/util/v0"
 )
 
-// InstallComputeSpaceControlPlaneComponents
+// InstallComputeSpaceControlPlaneComponents installs the Threeport control
+// plane components that are deployed to Threeport-managed compute space
+// clusters, i.e. clusters that do not have the Threeport control plane installed.
 func (cpi *ControlPlaneInstaller) InstallComputeSpaceControlPlaneComponents(
 	kubeClient dynamic.Interface,
 	mapper *meta.RESTMapper,


### PR DESCRIPTION
The terraform controller did not have the resource-manager permissions connected via IRSA.  This PR fixes this.

Also includes a bug fix for a panic when updating the Threeport config on control plane tear-down.