### PR TITLE
dev: support for pushing docker images to local registry

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -441,6 +441,7 @@ func DevUp() error {
 	devUp := exec.Command(
 		"./bin/tptdev",
 		"up",
+		"--force-overwrite-config",
 		"--auth-enabled=false",
 	)
 

--- a/magefile.go
+++ b/magefile.go
@@ -441,7 +441,6 @@ func DevUp() error {
 	devUp := exec.Command(
 		"./bin/tptdev",
 		"up",
-		"--force-overwrite-config",
 		"--auth-enabled=false",
 	)
 

--- a/pkg/threeport-installer/v0/tptdev/images.go
+++ b/pkg/threeport-installer/v0/tptdev/images.go
@@ -212,8 +212,22 @@ func PushDockerImage(tag string) error {
 	dockerUsername := os.Getenv("DOCKER_USERNAME")
 	dockerPassword := os.Getenv("DOCKER_PASSWORD")
 
+	var isLocal bool
+	parts := strings.Split(tag, "/")
+	if parts[0] == "localhost:5001" {
+		isLocal = true
+	}
+	fmt.Println("###########")
+	fmt.Println(isLocal)
+
 	// configure docker auth if credentials are present
 	switch {
+	case isLocal:
+		authConfig := registry.AuthConfig{}
+		authConfigBytes, _ := json.Marshal(authConfig)
+		authConfigEncoded := base64.URLEncoding.EncodeToString(authConfigBytes)
+		imagePushOptions.RegistryAuth = authConfigEncoded
+		break
 	case isDockerConfigPresent &&
 		dockerUsername == "" &&
 		dockerPassword == "":
@@ -267,6 +281,7 @@ func PushDockerImage(tag string) error {
 		authConfigBytes, _ := json.Marshal(authConfig)
 		authConfigEncoded := base64.URLEncoding.EncodeToString(authConfigBytes)
 		imagePushOptions.RegistryAuth = authConfigEncoded
+
 	}
 
 	// authenticate and push image

--- a/pkg/threeport-installer/v0/tptdev/images.go
+++ b/pkg/threeport-installer/v0/tptdev/images.go
@@ -217,8 +217,6 @@ func PushDockerImage(tag string) error {
 	if parts[0] == "localhost:5001" {
 		isLocal = true
 	}
-	fmt.Println("###########")
-	fmt.Println(isLocal)
 
 	// configure docker auth if credentials are present
 	switch {
@@ -227,7 +225,6 @@ func PushDockerImage(tag string) error {
 		authConfigBytes, _ := json.Marshal(authConfig)
 		authConfigEncoded := base64.URLEncoding.EncodeToString(authConfigBytes)
 		imagePushOptions.RegistryAuth = authConfigEncoded
-		break
 	case isDockerConfigPresent &&
 		dockerUsername == "" &&
 		dockerPassword == "":
@@ -281,7 +278,6 @@ func PushDockerImage(tag string) error {
 		authConfigBytes, _ := json.Marshal(authConfig)
 		authConfigEncoded := base64.URLEncoding.EncodeToString(authConfigBytes)
 		imagePushOptions.RegistryAuth = authConfigEncoded
-
 	}
 
 	// authenticate and push image


### PR DESCRIPTION
Updated the tptdev build function to support pushing Docker images to a local registry without requiring authentication for DockerHub.