### PR TITLE
fix: set helm manifest namespaces in post renderer

### DIFF
--- a/internal/helm-workload/post_renderer.go
+++ b/internal/helm-workload/post_renderer.go
@@ -70,6 +70,11 @@ func (p *ThreeportPostRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buf
 			return nil, fmt.Errorf("invalid Kubernetes manifest: missing Kind or apiVersion")
 		}
 
+		// Set the namespace - SetNamespace will only set it for namespaced resources
+		if p.HelmWorkloadInstance.ReleaseNamespace != nil {
+			kubeObject.SetNamespace(*p.HelmWorkloadInstance.ReleaseNamespace)
+		}
+
 		// set label metadata on object to signal threeport agent
 		kubeObject, err = kube.AddLabels(
 			kubeObject,

--- a/internal/helm-workload/v0_helm_workload_instance.go
+++ b/internal/helm-workload/v0_helm_workload_instance.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/go-logr/logr"
 	"helm.sh/helm/v3/pkg/action"
@@ -404,6 +405,11 @@ func getHelmActionConfig(
 	// create env settings and set repo config
 	settings := cli.New()
 	settings.RepositoryConfig = HelmRepoConfigFile
+
+	// ensure helm repo config directory exists
+	if err := os.MkdirAll(filepath.Dir(settings.RepositoryConfig), 0755); err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("failed to create helm repo config directory: %w", err)
+	}
 
 	// ensure helm repo config exists
 	if _, err := os.Stat(settings.RepositoryConfig); os.IsNotExist(err) {


### PR DESCRIPTION
This fix ensures the correct namespaces are set in all Helm resources before applying them to a given cluster.