### PR TITLE
feat: improve terminology for image namespaces vs repos

### DIFF
--- a/cmd/tptctl/cmd/up.go
+++ b/cmd/tptctl/cmd/up.go
@@ -113,11 +113,11 @@ func init() {
 	)
 	UpCmd.Flags().StringVarP(
 		&cliArgs.ControlPlaneImageRepo,
-		"control-plane-image-repo", "r", "", "Alternate image repo to pull threeport control plane images from.",
+		"control-plane-image-namespace", "r", "", "Alternate image namespace to pull threeport control plane images from.",
 	)
 	UpCmd.Flags().StringVarP(
 		&cliArgs.ControlPlaneImageTag,
-		"control-plane-image-tag", "t", "", "Alternate image tag to pull threeport control plane images from.",
+		"control-plane-image-tag", "t", "", "Alternate image tag for threeport control plane images.",
 	)
 	UpCmd.Flags().IntVar(
 		&cliArgs.NumWorkerNodes,

--- a/cmd/tptdev/cmd/build.go
+++ b/cmd/tptdev/cmd/build.go
@@ -175,11 +175,11 @@ func init() {
 	)
 	buildCmd.Flags().StringVarP(
 		&cliArgs.ControlPlaneImageRepo,
-		"control-plane-image-repo", "r", "", "Alternate image repo to pull threeport control plane images from.",
+		"control-plane-image-namespace", "r", "", "Alternate image namespace to pull threeport control plane images from.",
 	)
 	buildCmd.Flags().StringVarP(
 		&cliArgs.ControlPlaneImageTag,
-		"control-plane-image-tag", "t", "", "Alternate image tag to pull threeport control plane images from.",
+		"control-plane-image-tag", "t", "", "Alternate image tag for threeport control plane images.",
 	)
 	buildCmd.Flags().StringVar(
 		&arch,

--- a/cmd/tptdev/cmd/debug.go
+++ b/cmd/tptdev/cmd/debug.go
@@ -115,11 +115,11 @@ func init() {
 	)
 	DebugCmd.Flags().StringVarP(
 		&cliArgs.ControlPlaneImageRepo,
-		"control-plane-image-repo", "r", "", "Alternate image repo to pull threeport control plane images from.",
+		"control-plane-image-namespace", "r", "", "Alternate image namespace to pull threeport control plane images from.",
 	)
 	DebugCmd.Flags().StringVarP(
 		&cliArgs.ControlPlaneImageTag,
-		"control-plane-image-tag", "t", "", "Alternate image tag to pull threeport control plane images from.",
+		"control-plane-image-tag", "t", "", "Alternate image tag for threeport control plane images.",
 	)
 	DebugCmd.Flags().BoolVar(
 		&disable,

--- a/cmd/tptdev/cmd/up.go
+++ b/cmd/tptdev/cmd/up.go
@@ -78,11 +78,11 @@ func init() {
 	)
 	upCmd.Flags().StringVarP(
 		&cliArgs.ControlPlaneImageRepo,
-		"control-plane-image-repo", "r", "", "Alternate image repo to pull threeport control plane images from.",
+		"control-plane-image-namespace", "r", "", "Alternate image namespace to pull threeport control plane images from.",
 	)
 	upCmd.Flags().StringVarP(
 		&cliArgs.ControlPlaneImageTag,
-		"control-plane-image-tag", "t", "", "Alternate image tag to pull threeport control plane images from.",
+		"control-plane-image-tag", "t", "", "Alternate image tag for threeport control plane images.",
 	)
 	upCmd.Flags().BoolVar(
 		&cliArgs.ControlPlaneOnly,

--- a/docs/docs/sdk/tutorial.md
+++ b/docs/docs/sdk/tutorial.md
@@ -27,8 +27,10 @@ go mod init wordpress-threeport-module
 ## Create SDK Config
 
 Create a new file at the root of the repo called `sdk-config.yaml` with the
-following contents.  Replace the `ImageRepo` value for one that you have access
-to.
+following contents.  Replace the `ImageNamespace` value for one that you have access
+to.  The image namespace consists of the image registry and the namespace - which is usually
+a username or organization name, e.g. `docker.io/myuser`.  Multiple image repos will be
+created in this namespace; one for each module component.
 
 ```yaml
 ModuleName: Wordpress
@@ -38,7 +40,7 @@ ApiDocs:
   Description: API server for the Threeport WordPress module.
   ContactName: John Doe
   ContactEmail: john@example.com
-ImageRepo: ghcr.io/myorg/myimage
+ImageNamespace: ghcr.io/myorg
 ApiObjectGroups:
 - Name: wordpress
   Objects:

--- a/pkg/sdk/v0/config.go
+++ b/pkg/sdk/v0/config.go
@@ -23,9 +23,10 @@ type SdkConfig struct {
 	// domain name you own to make it globally unique.
 	ApiNamespace string `yaml:"ApiNamespace"`
 
-	// The image repository that will be used for builds of module
-	// components.
-	ImageRepo string `yaml:"ImageRepo"`
+	// The image namespace that will be used to store images for the module.
+	// Image namespace consists of `registry/namespace`, e.g. `docker.io/threeport`.
+	// A repository for each module will be created in this namespace.
+	ImageNamespace string `yaml:"ImageNamespace"`
 
 	// Details to be displayed with the API swagger docs that are served by the
 	// API server.

--- a/pkg/sdk/v0/gen/cmd/cli/install.go
+++ b/pkg/sdk/v0/gen/cmd/cli/install.go
@@ -248,10 +248,10 @@ func GenPluginInstallCmd(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 		Id("installCmd").Dot("Flags").Call().Dot("StringVarP").Call(
 			Line().Op("&").Id("controlPlaneImageRepo"),
 			Line().List(
-				Lit("control-plane-image-repo"),
+				Lit("control-plane-image-namespace"),
 				Lit("r"),
 				Qual(installerPkg, "ReleaseImageRepo"),
-				Lit("Image repo to pull threeport control plane images from."),
+				Lit("Image namespace to pull threeport control plane images from."),
 			),
 			Line(),
 		),
@@ -264,7 +264,7 @@ func GenPluginInstallCmd(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 					fmt.Sprintf("%s/internal/version", gen.ModulePath),
 					"GetVersion",
 				).Call(),
-				Lit("Image tag to pull threeport control plane images from."),
+				Lit("Image tag for threeport control plane images."),
 			),
 			Line(),
 		),

--- a/pkg/sdk/v0/gen/pkg/installer/installer.go
+++ b/pkg/sdk/v0/gen/pkg/installer/installer.go
@@ -44,7 +44,7 @@ func GenInstaller(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 	moduleNameLowerCamel := strcase.ToLowerCamel(sdkConfig.ModuleName)
 
 	f.Const().Defs(
-		Id("ReleaseImageRepo").Op("=").Lit(sdkConfig.ImageRepo),
+		Id("ReleaseImageRepo").Op("=").Lit(sdkConfig.ImageNamespace),
 		Id("DevImageRepo").Op("=").Lit("localhost:5001"),
 		Id("DbInitFilename").Op("=").Lit("db.sql"),
 		Id("DbInitLocation").Op("=").Lit("/etc/threeport/db-create"),

--- a/test/e2e/genesis_control_plane_test.go
+++ b/test/e2e/genesis_control_plane_test.go
@@ -290,7 +290,7 @@ func runTptctlUp() error {
 		threeportName,
 		"--provider",
 		provider,
-		"--control-plane-image-repo",
+		"--control-plane-image-namespace",
 		getImageRepo(imageRepo),
 		"--control-plane-image-tag",
 		imageTag,


### PR DESCRIPTION
There are two places that we've used the term "image repo" where we should have used "image namespace".  The former refers to a specific image's repo (without the tag), e.g. `ghcr.io/threeport/threeport-rest-api`. The latter refers to a namespace which contains multiple image repos, e.g. `ghcr.io/threeport` which is the correct term in these contexts.

* the flag `control-plane-image-repo` has been replaced with `control-plane-image-namespace
* the field `ImageRepo` in the SDK config has been replaced with `ImageNamespace`

Note: variable names were not updated, just the user-facing terms.