### PR TITLE
fix: an empty threeport config is no longer created if non-existent

### DIFF
--- a/cmd/tptctl/cmd/config_current_control_plane.go
+++ b/cmd/tptctl/cmd/config_current_control_plane.go
@@ -26,6 +26,7 @@ var ConfigCurrentControlPlaneCmd = &cobra.Command{
 	Long: `Set a threeport control plane as the current in-use control plane.  Once set as
 the current control plane all subsequent tptctl commands will apply to that Threeport
 control plane.`,
+	PreRun:       CommandPreRunFunc,
 	SilenceUsage: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		// get threeport config
@@ -183,7 +184,10 @@ func updateThreeportConfigWithControlPlaneInstance(apiClient *http.Client, apiEn
 		}
 	}
 
-	config.UpdateThreeportConfig(threeportConfig, threeportControlPlaneConfig)
+	if err := config.UpdateThreeportConfig(threeportConfig, threeportControlPlaneConfig); err != nil {
+		cli.Error("failed to update threeport config", err)
+		os.Exit(1)
+	}
 }
 
 func init() {

--- a/cmd/tptctl/cmd/config_get_control_planes.go
+++ b/cmd/tptctl/cmd/config_get_control_planes.go
@@ -20,6 +20,7 @@ var ConfigGetControlPlanesCmd = &cobra.Command{
 	Example:      "tptctl config get-control-planes",
 	Short:        "Get a list of threeport control planes in your threeport config",
 	Long:         `Get a list of threeport control planes in your threeport config.`,
+	PreRun:       CommandPreRunFunc,
 	SilenceUsage: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		// get threeport config

--- a/cmd/tptctl/cmd/down.go
+++ b/cmd/tptctl/cmd/down.go
@@ -16,6 +16,7 @@ var DownCmd = &cobra.Command{
 	Example:      "tptctl down --name my-threeport",
 	Short:        "Spin down a deployment of the Threeport control plane",
 	Long:         `Spin down a deployment of the Threeport control plane.`,
+	PreRun:       CommandPreRunFunc,
 	SilenceUsage: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		cpi, err := cliArgs.CreateInstaller()

--- a/cmd/tptctl/cmd/root.go
+++ b/cmd/tptctl/cmd/root.go
@@ -106,18 +106,22 @@ func init() {
 	)
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	cobra.OnInitialize(func() {
-		cli.InitConfig(cliArgs.CfgFile)
 		cli.InitArgs(cliArgs)
 	})
 }
 
+// CommandPreRunFunc is a function that is called before the command is executed.
+// It initializes the config and the command context.
 func CommandPreRunFunc(cmd *cobra.Command, args []string) {
+	cli.InitConfig(cmd, cliArgs.CfgFile)
+
 	if err := initializeCommandContext(cmd); err != nil {
 		cli.Error("could not initialize command in pre run:", err)
 		os.Exit(1)
 	}
 }
 
+// initializeCommandContext initializes the command context.
 func initializeCommandContext(cmd *cobra.Command) error {
 	// get threeport config and extract threeport API endpoint
 	threeportConfig, requestedControlPlane, err := config.GetThreeportConfig(cliArgs.ControlPlaneName)
@@ -144,6 +148,7 @@ func initializeCommandContext(cmd *cobra.Command) error {
 	return nil
 }
 
+// GetClientContext gets the client context from the command context.
 func GetClientContext(cmd *cobra.Command) (*http.Client, *config.ThreeportConfig, string, string) {
 	var apiClient *http.Client
 	var threeportConfig *config.ThreeportConfig

--- a/cmd/tptctl/cmd/up.go
+++ b/cmd/tptctl/cmd/up.go
@@ -38,8 +38,12 @@ var UpCmd = &cobra.Command{
 
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// create a new threeport config file if it doesn't exist
+		// set the config file path based on:
+		// 1. the config file path provided with a flag by the user
+		// 2. an environment variable
+		// 3. the default config file path
 		cfgFile := config.DetermineThreeportConfigPath(cliArgs.CfgFile)
+		// create a new threeport config file if it doesn't exist
 		if _, err := os.Stat(cfgFile); errors.Is(err, os.ErrNotExist) {
 			cfgDir := filepath.Dir(cfgFile)
 			if err := os.MkdirAll(cfgDir, os.ModePerm); err != nil {
@@ -50,19 +54,20 @@ var UpCmd = &cobra.Command{
 				cli.Error("failed to write Threeport config file to disk", err)
 				os.Exit(1)
 			}
-
-			viper.SetConfigFile(cfgFile)
-
 			// ensure config permissions are read/write for user only
 			if err := os.Chmod(cfgFile, 0600); err != nil {
 				cli.Error("failed to set permissions to read/write only", err)
 				os.Exit(1)
 			}
+		}
 
-			if err := viper.ReadInConfig(); err != nil {
-				cli.Error("failed to read config", err)
-				os.Exit(1)
-			}
+		// set the config file path
+		viper.SetConfigFile(cfgFile)
+
+		// read the config file
+		if err := viper.ReadInConfig(); err != nil {
+			cli.Error("failed to read config", err)
+			os.Exit(1)
 		}
 
 		// flag validation

--- a/cmd/tptdev/cmd/root.go
+++ b/cmd/tptdev/cmd/root.go
@@ -43,7 +43,7 @@ func init() {
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 
 	cobra.OnInitialize(func() {
-		cli.InitConfig(cliArgs.CfgFile)
+		cli.InitConfig(rootCmd, cliArgs.CfgFile)
 		cli.InitArgs(cliArgs)
 
 		cliArgs.InfraProvider = "kind"

--- a/cmd/tptdev/cmd/up.go
+++ b/cmd/tptdev/cmd/up.go
@@ -109,6 +109,6 @@ func init() {
 		"local-registry", false, "Connects a local container registry to Threeport control plane cluster.  Only applicable with provider 'kind'.",
 	)
 	cobra.OnInitialize(func() {
-		cli.InitConfig(cliArgs.CfgFile)
+		cli.InitConfig(upCmd, cliArgs.CfgFile)
 	})
 }

--- a/pkg/cli/v0/config.go
+++ b/pkg/cli/v0/config.go
@@ -4,63 +4,26 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 
-	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	config "github.com/threeport/threeport/pkg/config/v0"
 )
 
-const ThreeportConfigEnvKey = "THREEPORT_CONFIG"
-
 // InitConfig sets up the threeport config for a CLI.
-func InitConfig(cfgFile string) {
-	// determine user home dir
-	home, err := homedir.Dir()
-	if err != nil {
-		Error("failed to determine user home directory", err)
-		os.Exit(1)
-	}
+func InitConfig(cmd *cobra.Command, cfgFile string) {
+	cfgFile = config.DetermineThreeportConfigPath(cfgFile)
 
-	// check environment variable if cfgFile not set with flag
-	if cfgFile == "" {
-		envConfig, exists := os.LookupEnv(ThreeportConfigEnvKey)
-		if exists {
-			cfgFile = envConfig
-		}
-	}
-
-	// set default threeport config path if not set by user
-	if cfgFile == "" {
-		viper.AddConfigPath(config.DefaultThreeportConfigPath(home))
-		viper.SetConfigName(config.ThreeportConfigName)
-		viper.SetConfigType(config.ThreeportConfigType)
-		cfgFile = filepath.Join(
-			config.DefaultThreeportConfigPath(home),
-			fmt.Sprintf("%s.%s", config.ThreeportConfigName, config.ThreeportConfigType),
-		)
-	}
-
-	// create file if it doesn't exit
-	if _, err := os.Stat(cfgFile); errors.Is(err, os.ErrNotExist) {
-		if err := os.MkdirAll(config.DefaultThreeportConfigPath(home), os.ModePerm); err != nil {
-			Error("failed to create config directory", err)
-			os.Exit(1)
-		}
-		if err := viper.WriteConfigAs(cfgFile); err != nil {
-			Error("failed to write config to disk", err)
+	// ensure config file exists (except for up command which creates it)
+	if cmd.Use != "up" {
+		if _, err := os.Stat(cfgFile); errors.Is(err, os.ErrNotExist) {
+			Error(fmt.Sprintf("config file %s does not exist", cfgFile), err)
 			os.Exit(1)
 		}
 	}
 
 	viper.SetConfigFile(cfgFile)
-
-	// ensure config permissions are read/write for user only
-	if err := os.Chmod(cfgFile, 0600); err != nil {
-		Error("failed to set permissions to read/write only", err)
-		os.Exit(1)
-	}
 
 	if err := viper.ReadInConfig(); err != nil {
 		Error("failed to read config", err)

--- a/pkg/cli/v0/config.go
+++ b/pkg/cli/v0/config.go
@@ -16,7 +16,7 @@ func InitConfig(cmd *cobra.Command, cfgFile string) {
 	cfgFile = config.DetermineThreeportConfigPath(cfgFile)
 
 	// ensure config file exists (except for up command which creates it)
-	if cmd.Use != "up" {
+	if cmd != nil && cmd.Use != "up" {
 		if _, err := os.Stat(cfgFile); errors.Is(err, os.ErrNotExist) {
 			Error(fmt.Sprintf("config file %s does not exist", cfgFile), err)
 			os.Exit(1)

--- a/pkg/sdk/v0/gen/cmd/cli/root.go
+++ b/pkg/sdk/v0/gen/cmd/cli/root.go
@@ -89,17 +89,21 @@ func GenPluginRootCmd(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 		),
 		Qual("github.com/spf13/cobra", "OnInitialize").Call(
 			Func().Params().Block(
-				Id("cli").Dot("InitConfig").Call(Id("cliArgs").Dot("CfgFile")),
 				Id("cli").Dot("InitArgs").Call(Id("cliArgs")),
 			),
 		),
 	)
 	f.Line()
 
+	f.Comment("CommandPreRunFunc is a function that is called before the command is executed.")
+	f.Comment("It initializes the config and the command context.")
 	f.Func().Id("CommandPreRunFunc").Params(
 		Id("cmd").Op("*").Qual("github.com/spf13/cobra", "Command"),
 		Id("args").Index().String(),
 	).Block(
+		Id("cli").Dot("InitConfig").Call(Id("cmd"), Id("cliArgs").Dot("CfgFile")),
+		Line(),
+
 		If(
 			Err().Op(":=").Id("initializeCommandContext").Call(Id("cmd")),
 			Err().Op("!=").Nil(),
@@ -110,6 +114,7 @@ func GenPluginRootCmd(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 	)
 	f.Line()
 
+	f.Comment("initializeCommandContext initializes the command context.")
 	f.Func().Id("initializeCommandContext").Params(
 		Id("cmd").Op("*").Qual("github.com/spf13/cobra", "Command"),
 	).Params(

--- a/test/integration/workload_test.go
+++ b/test/integration/workload_test.go
@@ -73,7 +73,7 @@ func TestWorkloadE2E(t *testing.T) {
 		}
 
 		// initialize config so we can pull credentials from it
-		cli.InitConfig("")
+		cli.InitConfig(nil, "")
 
 		// get threeport config and configure http client for calls to threeport API
 		threeportConfig, _, err := config.GetThreeportConfig("")


### PR DESCRIPTION
Previously, if the threeport config did not exist, an empty threeport config would be created - and then an error about missing config data would be returned to the user.  This confusing behavior has been replaced by an error message if the threeport config doesn't exist.