### PR TITLE
test: ensure test failure if threeport-sdk produces any changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       run: mage install:sdk
 
     - name: Run threeport-sdk
-      run: threeport-sdk gen --config sdk-config.yaml
+      run: $GOPATH/bin/threeport-sdk gen --config sdk-config.yaml
 
     - name: Ensure no changes were made
       run: git diff --exit-code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    env:
+      GOPATH: /home/runner/go
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -29,7 +31,7 @@ jobs:
     - name: Run threeport-sdk
       run: $(go env GOPATH)/bin/threeport-sdk gen --config sdk-config.yaml
 
-    - name: Ensure no changes were made
+    - name: Ensure no changes were made by threeport-sdk
       run: git diff --exit-code
 
     - name: Create local container registry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       run: mage install:sdk
 
     - name: Run threeport-sdk
-      run: $GOPATH/bin/threeport-sdk gen --config sdk-config.yaml
+      run: $(go env GOPATH)/bin/threeport-sdk gen --config sdk-config.yaml
 
     - name: Ensure no changes were made
       run: git diff --exit-code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,15 @@ jobs:
     - name: Install mage
       run: go install github.com/magefile/mage@latest
 
+    - name: Install threeport-sdk
+      run: mage install:sdk
+
+    - name: Run threeport-sdk
+      run: threeport-sdk gen --config sdk-config.yaml
+
+    - name: Ensure no changes were made
+      run: git diff --exit-code
+
     - name: Create local container registry
       run: mage dev:localRegistryUp
 


### PR DESCRIPTION
It is important that the SDK and the code are in sync.  If the state of the SDK produces any changes to the source code in a PR, that is not the case.  This change causes a test failure if the SDK makes any changes.