### PR TITLE
fix: repair custom route association with handler funcs

### DIFF
--- a/pkg/api-server/v0/routes/routes.go
+++ b/pkg/api-server/v0/routes/routes.go
@@ -14,12 +14,6 @@ type CustomRoute struct {
 	// The API path for the route.
 	Path string
 
-	// If true, the route accepts an ID parameter that is used by the route's
-	// handler function.  If true, the route will be added to the API server.
-	// However, only the path (minus the ID parameter) will be registered with
-	// the API server.
-	IdParam bool
-
 	// The HTTP method for the route.
 	Method string
 
@@ -55,7 +49,6 @@ func CustomRoutes(h *handlers.Handler) []CustomRoute {
 		// Adds workload resource definitions in bulk.
 		{
 			Path:    v0.PathWorkloadResourceDefinitionSets,
-			IdParam: false,
 			Method:  "POST",
 			Handler: h.AddWorkloadResourceDefinitions,
 			ApiObjects: []ApiObject{
@@ -70,7 +63,6 @@ func CustomRoutes(h *handlers.Handler) []CustomRoute {
 		// route which deletes a single event by ID.
 		{
 			Path:    v0.PathWorkloadEvents,
-			IdParam: false,
 			Method:  "DELETE",
 			Handler: h.DeleteWorkloadEvents,
 			ApiObjects: []ApiObject{
@@ -84,7 +76,6 @@ func CustomRoutes(h *handlers.Handler) []CustomRoute {
 		// Joins attached object references for events.
 		{
 			Path:    v0.PathEventsJoinAttachedObjectReferences,
-			IdParam: false,
 			Method:  "GET",
 			Handler: h.GetEventsJoinAttachedObjectReferences,
 			ApiObjects: []ApiObject{
@@ -102,7 +93,6 @@ func CustomRoutes(h *handlers.Handler) []CustomRoute {
 		// Creates a module api route with a module object reference.
 		{
 			Path:    v0.PathModuleApiRouteWithModuleObjectReferences,
-			IdParam: false,
 			Method:  "POST",
 			Handler: h.AddModuleApiRouteWithModuleObjectReferences,
 			ApiObjects: []ApiObject{
@@ -120,9 +110,25 @@ func CustomRoutes(h *handlers.Handler) []CustomRoute {
 		// Gets module objects with associated module api routes.
 		{
 			Path:    v0.PathModuleObjectsWithModuleApiRoutes,
-			IdParam: true,
 			Method:  "GET",
 			Handler: h.GetModuleObjectsWithModuleApiRoutes,
+			ApiObjects: []ApiObject{
+				{
+					Name:    v0.ObjectTypeModuleObject,
+					Version: "v0",
+				},
+				{
+					Name:    v0.ObjectTypeModuleApiRoute,
+					Version: "v0",
+				},
+			},
+		},
+
+		// Gets a single module object by ID with associated module api routes.
+		{
+			Path:    v0.PathModuleObjectsWithModuleApiRoutes + "/:id",
+			Method:  "GET",
+			Handler: h.GetModuleObjectWithModuleApiRoutes,
 			ApiObjects: []ApiObject{
 				{
 					Name:    v0.ObjectTypeModuleObject,
@@ -140,9 +146,6 @@ func CustomRoutes(h *handlers.Handler) []CustomRoute {
 // AddCustomRoutes adds non-SDK-generated routes to API server for custom use cases.
 func AddCustomRoutes(e *echo.Echo, h *handlers.Handler) {
 	for _, route := range CustomRoutes(h) {
-		if route.IdParam {
-			e.Add(route.Method, route.Path+"/:id", route.Handler)
-		}
 		e.Add(route.Method, route.Path, route.Handler)
 	}
 }

--- a/pkg/sdk/v0/gen/pkg/api-server/add_custom_routes.go
+++ b/pkg/sdk/v0/gen/pkg/api-server/add_custom_routes.go
@@ -30,11 +30,32 @@ func GenAddCustomRoutes(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 			f.Comment("CustomRoute is a custom route for the API that defines the REST")
 			f.Comment("path, HTTP method, and handler function.")
 			f.Type().Id("CustomRoute").Struct(
+				Comment("The API's REST path for the custom route."),
 				Id("Path").String(),
+
+				Line().Comment("The HTTP method for the custom route."),
 				Id("Method").String(),
+
+				Line().Comment("The handler function for the custom route."),
 				Id("Handler").Func().Params(
 					Qual("github.com/labstack/echo/v4", "Context"),
 				).Error(),
+
+				Line().Comment("The API object type/s that the custom route serves."),
+				Comment("This is used to determine the ModuleObjects-ModuleApiRoute relationship"),
+				Comment("in module registration.  If the route serves multiple API objects, all"),
+				Comment("API objects must be included here."),
+				Id("ApiObjects").Index().Id("ApiObject"),
+			)
+			f.Line()
+
+			f.Comment("ApiObject is a type that represents an API object.")
+			f.Type().Id("ApiObject").Struct(
+				Comment("The name of the API object."),
+				Id("Name").String(),
+
+				Line().Comment("The version of the API object."),
+				Id("Version").String(),
 			)
 			f.Line()
 		}
@@ -88,7 +109,13 @@ func GenAddCustomRoutes(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 				Line(),
 				Comment("Add custom routes here.  Example:"),
 				Comment("return []CustomRoute{"),
-				Comment("    {Path: api_v0.PathObjectCustom, Method: \"GET\", Handler: h.GetObjectsForCustomPurpose},"),
+				Comment("    {"),
+				Comment("        Path: api_v0.PathCustomForSomeObject,"),
+				Comment("        Method: \"POST\","),
+				Comment("        Handler: h.CustomerHandlerForSomeObject, ApiObjects: []ApiObject{"),
+				Comment("            {Name: \"SomeObject\", Version: \"v0\"},"),
+				Comment("        },"),
+				Comment("    },"),
 				Comment("}"),
 				Return(Index().Id("CustomRoute").Values()),
 			)


### PR DESCRIPTION
Recently, an `IdParam` field was added to the `CustomRoute` object that caused REST paths with an ID parameter to be routed to the same handler function as those without an ID param.  This was a mistake since handler funcs that accept ID params are always different functions.  This mistake is corrected in this commit.

The SDK code generation for this file is also brought up-to-date with the addition of the `ApiObjects` field in the `CustomRoute` struct.