### PR TITLE
fix: eliminate panic when fetching module objects

### DIFF
--- a/cmd/tptctl/cmd/module_get_output.go
+++ b/cmd/tptctl/cmd/module_get_output.go
@@ -81,13 +81,17 @@ func outputGetv0ModuleObjectsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "VERSION\t NAME\t VERSION\t DESCRIPTION\t MODULE CONTROLLER\t MODULE API\t AGE")
 	for _, moduleObject := range *moduleObjects {
+		moduleControllerName := ""
+		if moduleObject.ModuleObject.ModuleController != nil {
+			moduleControllerName = *moduleObject.ModuleObject.ModuleController.Name
+		}
 		fmt.Fprintln(
 			writer,
 			"v0", "\t",
 			*moduleObject.ModuleObject.Name, "\t",
 			*moduleObject.ModuleObject.Version, "\t",
 			*moduleObject.ModuleObject.Description, "\t",
-			*moduleObject.ModuleObject.ModuleController.Name, "\t",
+			moduleControllerName, "\t",
 			*moduleObject.ModuleObject.ModuleApi.Name, "\t",
 			*moduleObject.ModuleObject.Age,
 		)

--- a/pkg/config/v0/module_object.go
+++ b/pkg/config/v0/module_object.go
@@ -66,25 +66,29 @@ func (m *ModuleObjectConfig) Get(
 		if err != nil {
 			return nil, fmt.Errorf("failed to get module api with id %d: %w", *moduleObject.ModuleApiID, err)
 		}
-		moduleController, err := client_v0.GetModuleControllerByID(apiClient, apiEndpoint, *moduleObject.ModuleControllerID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get module controller with id %d: %w", *moduleObject.ModuleControllerID, err)
-		}
 
 		moduleObjectConfig := ModuleObjectConfig{
 			ModuleObject: ModuleObjectValues{
 				Name:        moduleObject.Name,
 				Version:     moduleObject.Version,
 				Description: moduleObject.Description,
-				ModuleController: &ModuleControllerValues{
-					Name: moduleController.Name,
-				},
 				ModuleApi: &ModuleApiValues{
 					Name: moduleApi.Name,
 				},
 				Age: util.Ptr(util.GetAgeFormatted(moduleObject.CreatedAt)),
 			},
 		}
+
+		if moduleObject.ModuleControllerID != nil {
+			moduleController, err := client_v0.GetModuleControllerByID(apiClient, apiEndpoint, *moduleObject.ModuleControllerID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get module controller with id %d: %w", *moduleObject.ModuleControllerID, err)
+			}
+			moduleObjectConfig.ModuleObject.ModuleController = &ModuleControllerValues{
+				Name: moduleController.Name,
+			}
+		}
+
 		moduleObjectConfigs = append(moduleObjectConfigs, moduleObjectConfig)
 	}
 


### PR DESCRIPTION
Not all module objects (API objects) have a controller association in the database.  The objects that do not require controller reconciliation don't have a foreign key to the module controller table.  That was previously causing a panic when fetching module objects with tptctl. This commit fixes that problem.