### PR TITLE
fix: remove materialized view cleanup from extension module APIs

### DIFF
--- a/pkg/sdk/v0/gen/cmd/restapi/main.go
+++ b/pkg/sdk/v0/gen/cmd/restapi/main.go
@@ -459,12 +459,14 @@ func GenRestApiMain(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 			g.Line()
 		}
 
-		g.Comment("run cleanup of old materialized views every 60 seconds and drop views older than 15 minutes")
-		g.Qual(
-			fmt.Sprintf("%s/pkg/api-server/lib/v0", gen.ModulePath),
-			"CleanupMaterializedViews",
-		).Call(Id("db"), Op("&").Id("logger"), Lit(60), Lit(15))
-		g.Line()
+		if !gen.Module {
+			g.Comment("run cleanup of old materialized views every 60 seconds and drop views older than 15 minutes")
+			g.Qual(
+				fmt.Sprintf("%s/pkg/api-server/lib/v0", gen.ModulePath),
+				"CleanupMaterializedViews",
+			).Call(Id("db"), Op("&").Id("logger"), Lit(60), Lit(15))
+			g.Line()
+		}
 
 		g.Comment("nats connection")
 		g.Id("natsConn").Op(":=").Qual("fmt", "Sprintf").Call(


### PR DESCRIPTION
The Threeport SDK adds code to the main package of the Threeport API to clean up materialized view tables every 60 seconds.  These materialized views are used for cursor-based pagination.  The clean up only needs to be done by the Threeport API server.  The SDK was also adding it to the API server of each extension module.  This commit fixes this.