### PR TITLE
fix: return non-zero exit from tptctl when no defined instance exists

### DIFF
--- a/cmd/tptctl/cmd/kubernetes_runtime_get_output.go
+++ b/cmd/tptctl/cmd/kubernetes_runtime_get_output.go
@@ -18,6 +18,10 @@ func outputGetv0KubernetesRuntimesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "VERSION\t NAME\t KUBERNETES RUNTIME DEFINITION\t KUBERNETES RUNTIME INSTANCE\t INFRA PROVIDER\t HIGH AVAILABILITY\t INFRA PROVIDER ACCOUNT\t LOCATION\t DEFAULT RUNTIME\t FORCE DELETE\t AGE")
 	for _, kubernetesRuntime := range *kubernetesRuntimes {
+		infraProviderAcctName := ""
+		if kubernetesRuntime.KubernetesRuntime.InfraProviderAccountName != nil {
+			infraProviderAcctName = *kubernetesRuntime.KubernetesRuntime.InfraProviderAccountName
+		}
 		fmt.Fprintln(
 			writer,
 			"v0", "\t",
@@ -26,7 +30,7 @@ func outputGetv0KubernetesRuntimesCmd(
 			*kubernetesRuntime.KubernetesRuntime.Name, "\t",
 			*kubernetesRuntime.KubernetesRuntime.InfraProvider, "\t",
 			*kubernetesRuntime.KubernetesRuntime.HighAvailability, "\t",
-			*kubernetesRuntime.KubernetesRuntime.InfraProviderAccountName, "\t",
+			infraProviderAcctName, "\t",
 			*kubernetesRuntime.KubernetesRuntime.Location, "\t",
 			*kubernetesRuntime.KubernetesRuntime.DefaultRuntime, "\t",
 			*kubernetesRuntime.KubernetesRuntime.ForceDelete, "\t",

--- a/pkg/config/v0/aws_eks_kubernetes_runtime.go
+++ b/pkg/config/v0/aws_eks_kubernetes_runtime.go
@@ -179,9 +179,6 @@ func (a *AwsEksKubernetesRuntimeConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get aws eks kubernetes runtime definitions: %w", err)
 			}
-			if len(*awsEksKubernetesRuntimeDefinitions) == 0 {
-				return fmt.Errorf("failed to find any aws eks kubernetes runtime definitions: %w", err)
-			}
 			operatedAwsEksKubernetesRuntimeDefinitions = append(operatedAwsEksKubernetesRuntimeDefinitions, *awsEksKubernetesRuntimeDefinitions...)
 			return nil
 		},
@@ -227,13 +224,7 @@ func (a *AwsEksKubernetesRuntimeConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get aws eks kubernetes runtime instance with name %s: %w", *a.AwsEksKubernetesRuntime.Name, err)
 			}
-			if len(*awsEksKubernetesRuntimeInstance) == 0 {
-				return fmt.Errorf("failed to find aws eks kubernetes runtime instance with name %s: %w", *a.AwsEksKubernetesRuntime.Name, err)
-			}
-			if len(*awsEksKubernetesRuntimeInstance) > 1 {
-				return fmt.Errorf("multiple aws eks kubernetes runtime instances found with name %s: %w", *a.AwsEksKubernetesRuntime.Name, err)
-			}
-			operatedAwsEksKubernetesRuntimeInstances = append(operatedAwsEksKubernetesRuntimeInstances, (*awsEksKubernetesRuntimeInstance)[0])
+			operatedAwsEksKubernetesRuntimeInstances = append(operatedAwsEksKubernetesRuntimeInstances, *awsEksKubernetesRuntimeInstance...)
 			return nil
 		},
 		Name: "aws eks kubernetes runtime instance",

--- a/pkg/config/v0/control_plane.go
+++ b/pkg/config/v0/control_plane.go
@@ -174,9 +174,6 @@ func (c *ControlPlaneConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get control plane definitions: %w", err)
 			}
-			if len(*controlPlaneDefinitions) == 0 {
-				return fmt.Errorf("failed to find any control plane definitions: %w", err)
-			}
 			operatedControlPlaneDefinitions = append(operatedControlPlaneDefinitions, *controlPlaneDefinitions...)
 			return nil
 		},
@@ -224,13 +221,7 @@ func (c *ControlPlaneConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get control plane instance with name %s: %w", *c.ControlPlane.Name, err)
 			}
-			if len(*controlPlaneInstance) == 0 {
-				return fmt.Errorf("failed to find control plane instance with name %s: %w", *c.ControlPlane.Name, err)
-			}
-			if len(*controlPlaneInstance) > 1 {
-				return fmt.Errorf("multiple control plane instances found with name %s: %w", *c.ControlPlane.Name, err)
-			}
-			operatedControlPlaneInstances = append(operatedControlPlaneInstances, (*controlPlaneInstance)[0])
+			operatedControlPlaneInstances = append(operatedControlPlaneInstances, *controlPlaneInstance...)
 			return nil
 		},
 		Name: "control plane instance",

--- a/pkg/config/v0/domain_name.go
+++ b/pkg/config/v0/domain_name.go
@@ -173,9 +173,6 @@ func (d *DomainNameConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get domain name definitions: %w", err)
 			}
-			if len(*domainNameDefinitions) == 0 {
-				return fmt.Errorf("failed to find any domain name definitions: %w", err)
-			}
 			operatedDomainNameDefinitions = append(operatedDomainNameDefinitions, *domainNameDefinitions...)
 			return nil
 		},
@@ -222,13 +219,7 @@ func (d *DomainNameConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get domain name instance with name %s: %w", *d.DomainName.Name, err)
 			}
-			if len(*domainNameInstance) == 0 {
-				return fmt.Errorf("failed to find domain name instance with name %s: %w", *d.DomainName.Name, err)
-			}
-			if len(*domainNameInstance) > 1 {
-				return fmt.Errorf("multiple domain name instances found with name %s: %w", *d.DomainName.Name, err)
-			}
-			operatedDomainNameInstances = append(operatedDomainNameInstances, (*domainNameInstance)[0])
+			operatedDomainNameInstances = append(operatedDomainNameInstances, *domainNameInstance...)
 			return nil
 		},
 		Name: "domain name instance",

--- a/pkg/config/v0/gateway.go
+++ b/pkg/config/v0/gateway.go
@@ -177,9 +177,6 @@ func (g *GatewayConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get gateway definitions: %w", err)
 			}
-			if len(*gatewayDefinitions) == 0 {
-				return fmt.Errorf("failed to find any gateway definitions: %w", err)
-			}
 			operatedGatewayDefinitions = append(operatedGatewayDefinitions, *gatewayDefinitions...)
 			return nil
 		},
@@ -226,13 +223,7 @@ func (g *GatewayConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get gateway instance with name %s: %w", *g.Gateway.Name, err)
 			}
-			if len(*gatewayInstance) == 0 {
-				return fmt.Errorf("failed to find gateway instance with name %s: %w", *g.Gateway.Name, err)
-			}
-			if len(*gatewayInstance) > 1 {
-				return fmt.Errorf("multiple gateway instances found with name %s: %w", *g.Gateway.Name, err)
-			}
-			operatedGatewayInstances = append(operatedGatewayInstances, (*gatewayInstance)[0])
+			operatedGatewayInstances = append(operatedGatewayInstances, *gatewayInstance...)
 			return nil
 		},
 		Name: "gateway instance",

--- a/pkg/config/v0/helm_workload.go
+++ b/pkg/config/v0/helm_workload.go
@@ -235,13 +235,7 @@ func (h *HelmWorkloadConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get helm workload definition with name %s: %w", *helmWorkloadValues.Name, err)
 			}
-			if len(*helmWorkloadDefinition) == 0 {
-				return fmt.Errorf("failed to find helm workload definition with name %s: %w", *helmWorkloadValues.Name, err)
-			}
-			if len(*helmWorkloadDefinition) > 1 {
-				return fmt.Errorf("multiple helm workload definitions found with name %s: %w", *helmWorkloadValues.Name, err)
-			}
-			operatedHelmWorkloadDefinitions = append(operatedHelmWorkloadDefinitions, (*helmWorkloadDefinition)[0])
+			operatedHelmWorkloadDefinitions = append(operatedHelmWorkloadDefinitions, *helmWorkloadDefinition...)
 			return nil
 		},
 		Name: "helm workload definition",
@@ -295,13 +289,7 @@ func (h *HelmWorkloadConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get helm workload instance with name %s: %w", *helmWorkloadValues.Name, err)
 			}
-			if len(*helmWorkloadInstance) == 0 {
-				return fmt.Errorf("failed to find helm workload instance with name %s: %w", *helmWorkloadValues.Name, err)
-			}
-			if len(*helmWorkloadInstance) > 1 {
-				return fmt.Errorf("multiple helm workload instances found with name %s: %w", *helmWorkloadValues.Name, err)
-			}
-			operatedHelmWorkloadInstances = append(operatedHelmWorkloadInstances, (*helmWorkloadInstance)[0])
+			operatedHelmWorkloadInstances = append(operatedHelmWorkloadInstances, *helmWorkloadInstance...)
 			return nil
 		},
 		Name: "helm workload instance",

--- a/pkg/config/v0/kubernetes_runtime.go
+++ b/pkg/config/v0/kubernetes_runtime.go
@@ -179,9 +179,6 @@ func (k *KubernetesRuntimeConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get kubernetes runtime definitions: %w", err)
 			}
-			if len(*kubernetesRuntimeDefinitions) == 0 {
-				return fmt.Errorf("failed to find any kubernetes runtime definitions: %w", err)
-			}
 			operatedKubernetesRuntimeDefinitions = append(operatedKubernetesRuntimeDefinitions, *kubernetesRuntimeDefinitions...)
 			return nil
 		},
@@ -230,13 +227,7 @@ func (k *KubernetesRuntimeConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get kubernetes runtime instance with name %s: %w", *kubernetesRuntimeValues.Name, err)
 			}
-			if len(*kubernetesRuntimeInstance) == 0 {
-				return fmt.Errorf("failed to find kubernetes runtime instance with name %s: %w", *kubernetesRuntimeValues.Name, err)
-			}
-			if len(*kubernetesRuntimeInstance) > 1 {
-				return fmt.Errorf("multiple kubernetes runtime instances found with name %s: %w", *kubernetesRuntimeValues.Name, err)
-			}
-			operatedKubernetesRuntimeInstances = append(operatedKubernetesRuntimeInstances, (*kubernetesRuntimeInstance)[0])
+			operatedKubernetesRuntimeInstances = append(operatedKubernetesRuntimeInstances, *kubernetesRuntimeInstance...)
 			return nil
 		},
 		Name: "kubernetes runtime instance",

--- a/pkg/config/v0/observability_stack.go
+++ b/pkg/config/v0/observability_stack.go
@@ -206,13 +206,7 @@ func (o *ObservabilityStackConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get observability stack definition with name %s: %w", *observabilityStackValues.Name, err)
 			}
-			if len(*observabilityStackDefinition) == 0 {
-				return fmt.Errorf("failed to find observability stack definition with name %s: %w", *observabilityStackValues.Name, err)
-			}
-			if len(*observabilityStackDefinition) > 1 {
-				return fmt.Errorf("multiple observability stack definitions found with name %s: %w", *observabilityStackValues.Name, err)
-			}
-			operatedObservabilityStackDefinitions = append(operatedObservabilityStackDefinitions, (*observabilityStackDefinition)[0])
+			operatedObservabilityStackDefinitions = append(operatedObservabilityStackDefinitions, *observabilityStackDefinition...)
 			return nil
 		},
 		Name: "observability stack definition",
@@ -266,13 +260,7 @@ func (o *ObservabilityStackConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get observability stack instance with name %s: %w", *observabilityStackValues.Name, err)
 			}
-			if len(*observabilityStackInstance) == 0 {
-				return fmt.Errorf("failed to find observability stack instance with name %s: %w", *observabilityStackValues.Name, err)
-			}
-			if len(*observabilityStackInstance) > 1 {
-				return fmt.Errorf("multiple observability stack instances found with name %s: %w", *observabilityStackValues.Name, err)
-			}
-			operatedObservabilityStackInstances = append(operatedObservabilityStackInstances, (*observabilityStackInstance)[0])
+			operatedObservabilityStackInstances = append(operatedObservabilityStackInstances, *observabilityStackInstance...)
 			return nil
 		},
 		Name: "observability stack instance",

--- a/pkg/config/v0/oci_oke_kubernetes_runtime.go
+++ b/pkg/config/v0/oci_oke_kubernetes_runtime.go
@@ -175,9 +175,6 @@ func (o *OciOkeKubernetesRuntimeConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get oci oke kubernetes runtime definitions: %w", err)
 			}
-			if len(*ociOkeKubernetesRuntimeDefinitions) == 0 {
-				return fmt.Errorf("failed to find any oci oke kubernetes runtime definitions: %w", err)
-			}
 			operatedOciOkeKubernetesRuntimeDefinitions = append(operatedOciOkeKubernetesRuntimeDefinitions, *ociOkeKubernetesRuntimeDefinitions...)
 			return nil
 		},
@@ -221,13 +218,7 @@ func (o *OciOkeKubernetesRuntimeConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get oci oke kubernetes runtime instance with name %s: %w", *ociOkeKubernetesRuntimeValues.Name, err)
 			}
-			if len(*ociOkeKubernetesRuntimeInstance) == 0 {
-				return fmt.Errorf("failed to find oci oke kubernetes runtime instance with name %s: %w", *ociOkeKubernetesRuntimeValues.Name, err)
-			}
-			if len(*ociOkeKubernetesRuntimeInstance) > 1 {
-				return fmt.Errorf("multiple oci oke kubernetes runtime instances found with name %s: %w", *ociOkeKubernetesRuntimeValues.Name, err)
-			}
-			operatedOciOkeKubernetesRuntimeInstances = append(operatedOciOkeKubernetesRuntimeInstances, (*ociOkeKubernetesRuntimeInstance)[0])
+			operatedOciOkeKubernetesRuntimeInstances = append(operatedOciOkeKubernetesRuntimeInstances, *ociOkeKubernetesRuntimeInstance...)
 			return nil
 		},
 		Name: "oci oke kubernetes runtime instance",

--- a/pkg/config/v0/secret.go
+++ b/pkg/config/v0/secret.go
@@ -177,9 +177,6 @@ func (s *SecretConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get secret definitions: %w", err)
 			}
-			if len(*secretDefinitions) == 0 {
-				return fmt.Errorf("failed to find any secret definitions: %w", err)
-			}
 			operatedSecretDefinitions = append(operatedSecretDefinitions, *secretDefinitions...)
 			return nil
 		},
@@ -226,13 +223,7 @@ func (s *SecretConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get secret instance with name %s: %w", *secretValues.Name, err)
 			}
-			if len(*secretInstance) == 0 {
-				return fmt.Errorf("failed to find secret instance with name %s: %w", *secretValues.Name, err)
-			}
-			if len(*secretInstance) > 1 {
-				return fmt.Errorf("multiple secret instances found with name %s: %w", *secretValues.Name, err)
-			}
-			operatedSecretInstances = append(operatedSecretInstances, (*secretInstance)[0])
+			operatedSecretInstances = append(operatedSecretInstances, *secretInstance...)
 			return nil
 		},
 		Name: "secret instance",

--- a/pkg/config/v0/terraform.go
+++ b/pkg/config/v0/terraform.go
@@ -183,9 +183,6 @@ func (t *TerraformConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get terraform definitions: %w", err)
 			}
-			if len(*terraformDefinitions) == 0 {
-				return fmt.Errorf("failed to find any terraform definitions: %w", err)
-			}
 			operatedTerraformDefinitions = append(operatedTerraformDefinitions, *terraformDefinitions...)
 			return nil
 		},
@@ -234,10 +231,7 @@ func (t *TerraformConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get terraform instances: %w", err)
 			}
-			if len(*terraformInstance) == 0 {
-				return fmt.Errorf("failed to find any terraform instances: %w", err)
-			}
-			operatedTerraformInstances = append(operatedTerraformInstances, (*terraformInstance)[0])
+			operatedTerraformInstances = append(operatedTerraformInstances, *terraformInstance...)
 			return nil
 		},
 		Name: "terraform instance",

--- a/pkg/config/v0/workload.go
+++ b/pkg/config/v0/workload.go
@@ -177,9 +177,6 @@ func (w *WorkloadConfig) GetOperations(
 			if err != nil {
 				return fmt.Errorf("failed to get workload definitions: %w", err)
 			}
-			if len(*workloadDefinitions) == 0 {
-				return fmt.Errorf("failed to find any workload definitions: %w", err)
-			}
 			operatedWorkloadDefinitions = append(operatedWorkloadDefinitions, *workloadDefinitions...)
 			return nil
 		},
@@ -221,15 +218,9 @@ func (w *WorkloadConfig) GetOperations(
 		Get: func() error {
 			workloadInstance, err := workloadInstanceConfig.Get(apiClient, apiEndpoint)
 			if err != nil {
-				return fmt.Errorf("failed to get workload instance with name %s: %w", *workloadValues.Name, err)
+				return fmt.Errorf("failed to get workload instance/s: %w", err)
 			}
-			if len(*workloadInstance) == 0 {
-				return fmt.Errorf("failed to find workload instance with name %s: %w", *workloadValues.Name, err)
-			}
-			if len(*workloadInstance) > 1 {
-				return fmt.Errorf("multiple workload instances found with name %s: %w", *workloadValues.Name, err)
-			}
-			operatedWorkloadInstances = append(operatedWorkloadInstances, (*workloadInstance)[0])
+			operatedWorkloadInstances = append(operatedWorkloadInstances, *workloadInstance...)
 			return nil
 		},
 		Name: "workload instance",

--- a/pkg/sdk/v0/gen/pkg/config/config.go
+++ b/pkg/sdk/v0/gen/pkg/config/config.go
@@ -356,15 +356,6 @@ func GenConfig(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 											Id("err"),
 										)),
 									),
-									If(Id("len").Call(Op("*").Id(defsVar)).Op("==").Lit(0)).Block(
-										Return(Qual("fmt", "Errorf").Call(
-											Lit(fmt.Sprintf(
-												"failed to find any %s definitions: %%w",
-												defInstObjectHuman,
-											)),
-											Id("err"),
-										)),
-									),
 									Id(operatedDefsVar).Op("=").Id("append").Call(
 										Id(operatedDefsVar),
 										Op("*").Id(defsVar).Op("..."),
@@ -477,18 +468,9 @@ func GenConfig(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 											Id("err"),
 										)),
 									),
-									If(Id("len").Call(Op("*").Id(instsVar)).Op("==").Lit(0)).Block(
-										Return(Qual("fmt", "Errorf").Call(
-											Lit(fmt.Sprintf(
-												"failed to find any %s instances: %%w",
-												defInstObjectHuman,
-											)),
-											Id("err"),
-										)),
-									),
 									Id(operatedInstsVar).Op("=").Id("append").Call(
 										Id(operatedInstsVar),
-										Call(Op("*").Id(instsVar)).Index(Lit(0)),
+										Op("*").Id(instsVar).Op("..."),
 									),
 									Return(Nil()),
 								),


### PR DESCRIPTION
There was a bug in the config package that caused an error to be thrown when 'tptctl get [defined instance]' was run. The error was due to checks that returned errors when no records were found.  This check has been removed so that an empty array is returned from the config package. This restores the earlier behavior and retains the non-zero exit when no records found pattern for tptctl.