### PR TITLE
chore: remove VERSION column from tptctl tabular output

### DIFF
--- a/cmd/tptctl/cmd/actuator_get_output.go
+++ b/cmd/tptctl/cmd/actuator_get_output.go
@@ -16,11 +16,10 @@ func outputGetv0ProfilesCmd(
 	profiles *[]config_v0.ProfileConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t AGE")
+	fmt.Fprintln(writer, "NAME\t AGE")
 	for _, profile := range *profiles {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*profile.Profile.Name, "\t",
 			*profile.Profile.Age,
 		)
@@ -36,11 +35,10 @@ func outputGetv0TiersCmd(
 	tiers *[]config_v0.TierConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t CRITICALITY\t AGE")
+	fmt.Fprintln(writer, "NAME\t CRITICALITY\t AGE")
 	for _, tier := range *tiers {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*tier.Tier.Name, "\t",
 			*tier.Tier.Criticality, "\t",
 			*tier.Tier.Age,

--- a/cmd/tptctl/cmd/aws_get_output.go
+++ b/cmd/tptctl/cmd/aws_get_output.go
@@ -18,13 +18,17 @@ func outputGetv0AwsAccountsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t DEFAULT ACCOUNT\t DEFAULT REGION\t ACCOUNT ID\t AGE")
 	for _, awsAccount := range *awsAccounts {
+		age := ""
+		if awsAccount.AwsAccount.Age != nil {
+			age = *awsAccount.AwsAccount.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*awsAccount.AwsAccount.Name, "\t",
 			*awsAccount.AwsAccount.DefaultAccount, "\t",
 			*awsAccount.AwsAccount.DefaultRegion, "\t",
 			*awsAccount.AwsAccount.AccountID, "\t",
-			*awsAccount.AwsAccount.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -40,14 +44,26 @@ func outputGetv0AwsEksKubernetesRuntimesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t AWS EKS KUBERNETES DEFINITION NAME\t AWS EKS KUBERNETES INSTANCE NAME\t REGION\t RECONCILED\t AGE")
 	for _, awsEksKubernetesRuntime := range *awsEksKubernetesRuntimes {
+		region := ""
+		if awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Region != nil {
+			region = *awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Region
+		}
+		reconciled := false
+		if awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Reconciled != nil {
+			reconciled = *awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Reconciled
+		}
+		age := ""
+		if awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Age != nil {
+			age = *awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Name, "\t",
 			*awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Name, "\t",
 			*awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Name, "\t",
-			*awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Region, "\t",
-			*awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Reconciled, "\t",
-			*awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Age,
+			region, "\t",
+			reconciled, "\t",
+			age,
 		)
 	}
 	writer.Flush()
@@ -63,6 +79,10 @@ func outputGetv0AwsEksKubernetesRuntimeDefinitionsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t AWS ACCOUNT\t ZONE COUNT\t DEFAULT NODE GROUP INSTANCE TYPE\t DEFAULT NODE GROUP MINIMUM SIZE\t DEFAULT NODE GROUP MAXIMUM SIZE\t AGE")
 	for _, awsEksKubernetesRuntimeDefinition := range *awsEksKubernetesRuntimeDefinitions {
+		age := ""
+		if awsEksKubernetesRuntimeDefinition.AwsEksKubernetesRuntimeDefinition.Age != nil {
+			age = *awsEksKubernetesRuntimeDefinition.AwsEksKubernetesRuntimeDefinition.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*awsEksKubernetesRuntimeDefinition.AwsEksKubernetesRuntimeDefinition.Name, "\t",
@@ -71,7 +91,7 @@ func outputGetv0AwsEksKubernetesRuntimeDefinitionsCmd(
 			*awsEksKubernetesRuntimeDefinition.AwsEksKubernetesRuntimeDefinition.DefaultNodeGroupInstanceType, "\t",
 			*awsEksKubernetesRuntimeDefinition.AwsEksKubernetesRuntimeDefinition.DefaultNodeGroupMinimumSize, "\t",
 			*awsEksKubernetesRuntimeDefinition.AwsEksKubernetesRuntimeDefinition.DefaultNodeGroupMaximumSize, "\t",
-			*awsEksKubernetesRuntimeDefinition.AwsEksKubernetesRuntimeDefinition.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -87,14 +107,36 @@ func outputGetv0AwsEksKubernetesRuntimeInstancesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t REGION\t KUBERNETES RUNTIME INSTANCE NAME\t AWS EKS KUBERNETES DEFINITION NAME\t RECONCILED\t AGE")
 	for _, awsEksKubernetesRuntimeInstance := range *awsEksKubernetesRuntimeInstances {
+		region := ""
+		if awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.Region != nil {
+			region = *awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.Region
+		}
+		kubernetesRuntimeInstanceName := ""
+		if awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.KubernetesRuntimeInstance != nil &&
+			awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.KubernetesRuntimeInstance.Name != nil {
+			kubernetesRuntimeInstanceName = *awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.KubernetesRuntimeInstance.Name
+		}
+		awsEksDefinitionName := ""
+		if awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeDefinition != nil &&
+			awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeDefinition.Name != nil {
+			awsEksDefinitionName = *awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeDefinition.Name
+		}
+		reconciled := false
+		if awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.Reconciled != nil {
+			reconciled = *awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.Reconciled
+		}
+		age := ""
+		if awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.Age != nil {
+			age = *awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.Name, "\t",
-			*awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.Region, "\t",
-			*awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.KubernetesRuntimeInstance.Name, "\t",
-			*awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeDefinition.Name, "\t",
-			*awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.Reconciled, "\t",
-			*awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.Age,
+			region, "\t",
+			kubernetesRuntimeInstanceName, "\t",
+			awsEksDefinitionName, "\t",
+			reconciled, "\t",
+			age,
 		)
 	}
 	writer.Flush()

--- a/cmd/tptctl/cmd/aws_get_output.go
+++ b/cmd/tptctl/cmd/aws_get_output.go
@@ -16,11 +16,10 @@ func outputGetv0AwsAccountsCmd(
 	awsAccounts *[]config_v0.AwsAccountConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t DEFAULT ACCOUNT\t DEFAULT REGION\t ACCOUNT ID\t AGE")
+	fmt.Fprintln(writer, "NAME\t DEFAULT ACCOUNT\t DEFAULT REGION\t ACCOUNT ID\t AGE")
 	for _, awsAccount := range *awsAccounts {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*awsAccount.AwsAccount.Name, "\t",
 			*awsAccount.AwsAccount.DefaultAccount, "\t",
 			*awsAccount.AwsAccount.DefaultRegion, "\t",
@@ -39,11 +38,10 @@ func outputGetv0AwsEksKubernetesRuntimesCmd(
 	awsEksKubernetesRuntimes *[]config_v0.AwsEksKubernetesRuntimeConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t AWS EKS KUBERNETES DEFINITION NAME\t AWS EKS KUBERNETES INSTANCE NAME\t REGION\t RECONCILED\t AGE")
+	fmt.Fprintln(writer, "NAME\t AWS EKS KUBERNETES DEFINITION NAME\t AWS EKS KUBERNETES INSTANCE NAME\t REGION\t RECONCILED\t AGE")
 	for _, awsEksKubernetesRuntime := range *awsEksKubernetesRuntimes {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Name, "\t",
 			*awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Name, "\t",
 			*awsEksKubernetesRuntime.AwsEksKubernetesRuntime.Name, "\t",
@@ -63,11 +61,10 @@ func outputGetv0AwsEksKubernetesRuntimeDefinitionsCmd(
 	awsEksKubernetesRuntimeDefinitions *[]config_v0.AwsEksKubernetesRuntimeDefinitionConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t AWS ACCOUNT\t ZONE COUNT\t DEFAULT NODE GROUP INSTANCE TYPE\t DEFAULT NODE GROUP MINIMUM SIZE\t DEFAULT NODE GROUP MAXIMUM SIZE\t AGE")
+	fmt.Fprintln(writer, "NAME\t AWS ACCOUNT\t ZONE COUNT\t DEFAULT NODE GROUP INSTANCE TYPE\t DEFAULT NODE GROUP MINIMUM SIZE\t DEFAULT NODE GROUP MAXIMUM SIZE\t AGE")
 	for _, awsEksKubernetesRuntimeDefinition := range *awsEksKubernetesRuntimeDefinitions {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*awsEksKubernetesRuntimeDefinition.AwsEksKubernetesRuntimeDefinition.Name, "\t",
 			*awsEksKubernetesRuntimeDefinition.AwsEksKubernetesRuntimeDefinition.AwsAccountName, "\t",
 			*awsEksKubernetesRuntimeDefinition.AwsEksKubernetesRuntimeDefinition.ZoneCount, "\t",
@@ -88,11 +85,10 @@ func outputGetv0AwsEksKubernetesRuntimeInstancesCmd(
 	awsEksKubernetesRuntimeInstances *[]config_v0.AwsEksKubernetesRuntimeInstanceConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t REGION\t KUBERNETES RUNTIME INSTANCE NAME\t AWS EKS KUBERNETES DEFINITION NAME\t RECONCILED\t AGE")
+	fmt.Fprintln(writer, "NAME\t REGION\t KUBERNETES RUNTIME INSTANCE NAME\t AWS EKS KUBERNETES DEFINITION NAME\t RECONCILED\t AGE")
 	for _, awsEksKubernetesRuntimeInstance := range *awsEksKubernetesRuntimeInstances {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.Name, "\t",
 			*awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.Region, "\t",
 			*awsEksKubernetesRuntimeInstance.AwsEksKubernetesRuntimeInstance.KubernetesRuntimeInstance.Name, "\t",

--- a/cmd/tptctl/cmd/control_plane_get_output.go
+++ b/cmd/tptctl/cmd/control_plane_get_output.go
@@ -16,11 +16,10 @@ func outputGetv0ControlPlanesCmd(
 	controlPlanes *[]config_v0.ControlPlaneConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t CONTROL PLANE DEFINITION\t CONTROL PLANE INSTANCE\t AUTH ENABLED\t GENESIS CONTROL PLANE\t KUBERNETES RUNTIME INSTANCE\t AGE")
+	fmt.Fprintln(writer, "NAME\t CONTROL PLANE DEFINITION\t CONTROL PLANE INSTANCE\t AUTH ENABLED\t GENESIS CONTROL PLANE\t KUBERNETES RUNTIME INSTANCE\t AGE")
 	for _, controlPlane := range *controlPlanes {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*controlPlane.ControlPlane.Name, "\t",
 			*controlPlane.ControlPlane.Name, "\t",
 			*controlPlane.ControlPlane.Name, "\t",
@@ -41,11 +40,10 @@ func outputGetv0ControlPlaneDefinitionsCmd(
 	controlPlaneDefinitions *[]config_v0.ControlPlaneDefinitionConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t AUTH ENABLED\t AGE")
+	fmt.Fprintln(writer, "NAME\t AUTH ENABLED\t AGE")
 	for _, controlPlaneDefinition := range *controlPlaneDefinitions {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*controlPlaneDefinition.ControlPlaneDefinition.Name, "\t",
 			*controlPlaneDefinition.ControlPlaneDefinition.AuthEnabled, "\t",
 			*controlPlaneDefinition.ControlPlaneDefinition.Age,
@@ -62,11 +60,10 @@ func outputGetv0ControlPlaneInstancesCmd(
 	controlPlaneInstances *[]config_v0.ControlPlaneInstanceConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t GENESIS CONTROL PLANE\t CONTROL PLANE DEFINITION\t KUBERNETES RUNTIME INSTANCE\t AGE")
+	fmt.Fprintln(writer, "NAME\t GENESIS CONTROL PLANE\t CONTROL PLANE DEFINITION\t KUBERNETES RUNTIME INSTANCE\t AGE")
 	for _, controlPlaneInstance := range *controlPlaneInstances {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*controlPlaneInstance.ControlPlaneInstance.Name, "\t",
 			*controlPlaneInstance.ControlPlaneInstance.Genesis, "\t",
 			*controlPlaneInstance.ControlPlaneInstance.ControlPlaneDefinition.Name, "\t",

--- a/cmd/tptctl/cmd/control_plane_get_output.go
+++ b/cmd/tptctl/cmd/control_plane_get_output.go
@@ -18,6 +18,15 @@ func outputGetv0ControlPlanesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t CONTROL PLANE DEFINITION\t CONTROL PLANE INSTANCE\t AUTH ENABLED\t GENESIS CONTROL PLANE\t KUBERNETES RUNTIME INSTANCE\t AGE")
 	for _, controlPlane := range *controlPlanes {
+		kubernetesRuntimeInstanceName := ""
+		if controlPlane.ControlPlane.KubernetesRuntimeInstance != nil &&
+			controlPlane.ControlPlane.KubernetesRuntimeInstance.Name != nil {
+			kubernetesRuntimeInstanceName = *controlPlane.ControlPlane.KubernetesRuntimeInstance.Name
+		}
+		age := ""
+		if controlPlane.ControlPlane.Age != nil {
+			age = *controlPlane.ControlPlane.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*controlPlane.ControlPlane.Name, "\t",
@@ -25,8 +34,8 @@ func outputGetv0ControlPlanesCmd(
 			*controlPlane.ControlPlane.Name, "\t",
 			*controlPlane.ControlPlane.AuthEnabled, "\t",
 			*controlPlane.ControlPlane.Genesis, "\t",
-			*controlPlane.ControlPlane.KubernetesRuntimeInstance.Name, "\t",
-			*controlPlane.ControlPlane.Age,
+			kubernetesRuntimeInstanceName, "\t",
+			age,
 		)
 	}
 	writer.Flush()
@@ -42,11 +51,15 @@ func outputGetv0ControlPlaneDefinitionsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t AUTH ENABLED\t AGE")
 	for _, controlPlaneDefinition := range *controlPlaneDefinitions {
+		age := ""
+		if controlPlaneDefinition.ControlPlaneDefinition.Age != nil {
+			age = *controlPlaneDefinition.ControlPlaneDefinition.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*controlPlaneDefinition.ControlPlaneDefinition.Name, "\t",
 			*controlPlaneDefinition.ControlPlaneDefinition.AuthEnabled, "\t",
-			*controlPlaneDefinition.ControlPlaneDefinition.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -62,13 +75,27 @@ func outputGetv0ControlPlaneInstancesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t GENESIS CONTROL PLANE\t CONTROL PLANE DEFINITION\t KUBERNETES RUNTIME INSTANCE\t AGE")
 	for _, controlPlaneInstance := range *controlPlaneInstances {
+		controlPlaneDefinitionName := ""
+		if controlPlaneInstance.ControlPlaneInstance.ControlPlaneDefinition != nil &&
+			controlPlaneInstance.ControlPlaneInstance.ControlPlaneDefinition.Name != nil {
+			controlPlaneDefinitionName = *controlPlaneInstance.ControlPlaneInstance.ControlPlaneDefinition.Name
+		}
+		kubernetesRuntimeInstanceName := ""
+		if controlPlaneInstance.ControlPlaneInstance.KubernetesRuntimeInstance != nil &&
+			controlPlaneInstance.ControlPlaneInstance.KubernetesRuntimeInstance.Name != nil {
+			kubernetesRuntimeInstanceName = *controlPlaneInstance.ControlPlaneInstance.KubernetesRuntimeInstance.Name
+		}
+		age := ""
+		if controlPlaneInstance.ControlPlaneInstance.Age != nil {
+			age = *controlPlaneInstance.ControlPlaneInstance.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*controlPlaneInstance.ControlPlaneInstance.Name, "\t",
 			*controlPlaneInstance.ControlPlaneInstance.Genesis, "\t",
-			*controlPlaneInstance.ControlPlaneInstance.ControlPlaneDefinition.Name, "\t",
-			*controlPlaneInstance.ControlPlaneInstance.KubernetesRuntimeInstance.Name, "\t",
-			*controlPlaneInstance.ControlPlaneInstance.Age,
+			controlPlaneDefinitionName, "\t",
+			kubernetesRuntimeInstanceName, "\t",
+			age,
 		)
 	}
 	writer.Flush()

--- a/cmd/tptctl/cmd/gateway_get_output.go
+++ b/cmd/tptctl/cmd/gateway_get_output.go
@@ -18,6 +18,15 @@ func outputGetv0DomainNamesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t DOMAIN NAME DEFINITION\t DOMAIN NAME INSTANCE\t DOMAIN\t ZONE\t ADMIN EMAIL\t WORKLOAD INSTANCE\t AGE")
 	for _, domainName := range *domainNames {
+		workloadInstanceName := ""
+		if domainName.DomainName.WorkloadInstance != nil &&
+			domainName.DomainName.WorkloadInstance.Name != nil {
+			workloadInstanceName = *domainName.DomainName.WorkloadInstance.Name
+		}
+		age := ""
+		if domainName.DomainName.Age != nil {
+			age = *domainName.DomainName.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*domainName.DomainName.Name, "\t",
@@ -26,8 +35,8 @@ func outputGetv0DomainNamesCmd(
 			*domainName.DomainName.Domain, "\t",
 			*domainName.DomainName.Zone, "\t",
 			*domainName.DomainName.AdminEmail, "\t",
-			*domainName.DomainName.WorkloadInstance.Name, "\t",
-			*domainName.DomainName.Age,
+			workloadInstanceName, "\t",
+			age,
 		)
 	}
 	writer.Flush()
@@ -43,13 +52,17 @@ func outputGetv0DomainNameDefinitionsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t DOMAIN\t ZONE\t ADMIN EMAIL\t AGE ")
 	for _, domainNameDefinition := range *domainNameDefinitions {
+		age := ""
+		if domainNameDefinition.DomainNameDefinition.Age != nil {
+			age = *domainNameDefinition.DomainNameDefinition.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*domainNameDefinition.DomainNameDefinition.Name, "\t",
 			*domainNameDefinition.DomainNameDefinition.Domain, "\t",
 			*domainNameDefinition.DomainNameDefinition.Zone, "\t",
 			*domainNameDefinition.DomainNameDefinition.AdminEmail, "\t",
-			*domainNameDefinition.DomainNameDefinition.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -65,13 +78,32 @@ func outputGetv0DomainNameInstancesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t DOMAIN NAME DEFINITION\t KUBERNETES RUNTIME INSTANCE\t WORKLOAD INSTANCE\t AGE")
 	for _, domainNameInstance := range *domainNameInstances {
+		domainNameDefinitionName := ""
+		if domainNameInstance.DomainNameInstance.DomainNameDefinition != nil &&
+			domainNameInstance.DomainNameInstance.DomainNameDefinition.Name != nil {
+			domainNameDefinitionName = *domainNameInstance.DomainNameInstance.DomainNameDefinition.Name
+		}
+		kubernetesRuntimeInstanceName := ""
+		if domainNameInstance.DomainNameInstance.KubernetesRuntimeInstance != nil &&
+			domainNameInstance.DomainNameInstance.KubernetesRuntimeInstance.Name != nil {
+			kubernetesRuntimeInstanceName = *domainNameInstance.DomainNameInstance.KubernetesRuntimeInstance.Name
+		}
+		workloadInstanceName := ""
+		if domainNameInstance.DomainNameInstance.WorkloadInstance != nil &&
+			domainNameInstance.DomainNameInstance.WorkloadInstance.Name != nil {
+			workloadInstanceName = *domainNameInstance.DomainNameInstance.WorkloadInstance.Name
+		}
+		age := ""
+		if domainNameInstance.DomainNameInstance.Age != nil {
+			age = *domainNameInstance.DomainNameInstance.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*domainNameInstance.DomainNameInstance.Name, "\t",
-			*domainNameInstance.DomainNameInstance.DomainNameDefinition.Name, "\t",
-			*domainNameInstance.DomainNameInstance.KubernetesRuntimeInstance.Name, "\t",
-			*domainNameInstance.DomainNameInstance.WorkloadInstance.Name, "\t",
-			*domainNameInstance.DomainNameInstance.Age,
+			domainNameDefinitionName, "\t",
+			kubernetesRuntimeInstanceName, "\t",
+			workloadInstanceName, "\t",
+			age,
 		)
 	}
 	writer.Flush()
@@ -87,19 +119,54 @@ func outputGetv0GatewaysCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t GATEWAY DEFINITION\t GATEWAY INSTANCE\t HTTP PORTS\t TCP PORTS\t SUBDOMAIN\t KUBERNETES SERVICE NAME\t DOMAIN NAME DEFINITION\t KUBERNETES RUNTIME INSTANCE\t WORKLOAD INSTANCE\t AGE")
 	for _, gateway := range *gateways {
+		httpPorts := ""
+		if gateway.Gateway.HttpPorts != nil {
+			httpPorts = fmt.Sprintf("%v", *gateway.Gateway.HttpPorts)
+		}
+		tcpPorts := ""
+		if gateway.Gateway.TcpPorts != nil {
+			tcpPorts = fmt.Sprintf("%v", *gateway.Gateway.TcpPorts)
+		}
+		subDomain := ""
+		if gateway.Gateway.SubDomain != nil {
+			subDomain = *gateway.Gateway.SubDomain
+		}
+		serviceName := ""
+		if gateway.Gateway.ServiceName != nil {
+			serviceName = *gateway.Gateway.ServiceName
+		}
+		domainNameDefinitionName := ""
+		if gateway.Gateway.DomainNameDefinition != nil &&
+			gateway.Gateway.DomainNameDefinition.Name != nil {
+			domainNameDefinitionName = *gateway.Gateway.DomainNameDefinition.Name
+		}
+		kubernetesRuntimeInstanceName := ""
+		if gateway.Gateway.KubernetesRuntimeInstance != nil &&
+			gateway.Gateway.KubernetesRuntimeInstance.Name != nil {
+			kubernetesRuntimeInstanceName = *gateway.Gateway.KubernetesRuntimeInstance.Name
+		}
+		workloadInstanceName := ""
+		if gateway.Gateway.WorkloadInstance != nil &&
+			gateway.Gateway.WorkloadInstance.Name != nil {
+			workloadInstanceName = *gateway.Gateway.WorkloadInstance.Name
+		}
+		age := ""
+		if gateway.Gateway.Age != nil {
+			age = *gateway.Gateway.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*gateway.Gateway.Name, "\t",
 			*gateway.Gateway.Name, "\t",
 			*gateway.Gateway.Name, "\t",
-			*gateway.Gateway.HttpPorts, "\t",
-			*gateway.Gateway.TcpPorts, "\t",
-			*gateway.Gateway.SubDomain, "\t",
-			*gateway.Gateway.ServiceName, "\t",
-			*gateway.Gateway.DomainNameDefinition.Name, "\t",
-			*gateway.Gateway.KubernetesRuntimeInstance.Name, "\t",
-			*gateway.Gateway.WorkloadInstance.Name, "\t",
-			*gateway.Gateway.Age,
+			httpPorts, "\t",
+			tcpPorts, "\t",
+			subDomain, "\t",
+			serviceName, "\t",
+			domainNameDefinitionName, "\t",
+			kubernetesRuntimeInstanceName, "\t",
+			workloadInstanceName, "\t",
+			age,
 		)
 	}
 	writer.Flush()
@@ -115,15 +182,40 @@ func outputGetv0GatewayDefinitionsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t HTTP PORTS\t TCP PORTS\t SUBDOMAIN\t KUBERNETES SERVICE NAME\t DOMAIN NAME DEFINITION\t AGE")
 	for _, gatewayDefinition := range *gatewayDefinitions {
+		httpPorts := ""
+		if gatewayDefinition.GatewayDefinition.HttpPorts != nil {
+			httpPorts = fmt.Sprintf("%v", *gatewayDefinition.GatewayDefinition.HttpPorts)
+		}
+		tcpPorts := ""
+		if gatewayDefinition.GatewayDefinition.TcpPorts != nil {
+			tcpPorts = fmt.Sprintf("%v", *gatewayDefinition.GatewayDefinition.TcpPorts)
+		}
+		subDomain := ""
+		if gatewayDefinition.GatewayDefinition.SubDomain != nil {
+			subDomain = *gatewayDefinition.GatewayDefinition.SubDomain
+		}
+		serviceName := ""
+		if gatewayDefinition.GatewayDefinition.ServiceName != nil {
+			serviceName = *gatewayDefinition.GatewayDefinition.ServiceName
+		}
+		domainNameDefinitionName := ""
+		if gatewayDefinition.GatewayDefinition.DomainNameDefinition != nil &&
+			gatewayDefinition.GatewayDefinition.DomainNameDefinition.Name != nil {
+			domainNameDefinitionName = *gatewayDefinition.GatewayDefinition.DomainNameDefinition.Name
+		}
+		age := ""
+		if gatewayDefinition.GatewayDefinition.Age != nil {
+			age = *gatewayDefinition.GatewayDefinition.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*gatewayDefinition.GatewayDefinition.Name, "\t",
-			*gatewayDefinition.GatewayDefinition.HttpPorts, "\t",
-			*gatewayDefinition.GatewayDefinition.TcpPorts, "\t",
-			*gatewayDefinition.GatewayDefinition.SubDomain, "\t",
-			*gatewayDefinition.GatewayDefinition.ServiceName, "\t",
-			*gatewayDefinition.GatewayDefinition.DomainNameDefinition.Name, "\t",
-			*gatewayDefinition.GatewayDefinition.Age,
+			httpPorts, "\t",
+			tcpPorts, "\t",
+			subDomain, "\t",
+			serviceName, "\t",
+			domainNameDefinitionName, "\t",
+			age,
 		)
 	}
 	writer.Flush()
@@ -139,13 +231,32 @@ func outputGetv0GatewayInstancesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t GATEWAY DEFINITION\t KUBERNETES RUNTIME INSTANCE\t WORKLOAD INSTANCE\t AGE")
 	for _, gatewayInstance := range *gatewayInstances {
+		gatewayDefinitionName := ""
+		if gatewayInstance.GatewayInstance.GatewayDefinition != nil &&
+			gatewayInstance.GatewayInstance.GatewayDefinition.Name != nil {
+			gatewayDefinitionName = *gatewayInstance.GatewayInstance.GatewayDefinition.Name
+		}
+		kubernetesRuntimeInstanceName := ""
+		if gatewayInstance.GatewayInstance.KubernetesRuntimeInstance != nil &&
+			gatewayInstance.GatewayInstance.KubernetesRuntimeInstance.Name != nil {
+			kubernetesRuntimeInstanceName = *gatewayInstance.GatewayInstance.KubernetesRuntimeInstance.Name
+		}
+		workloadInstanceName := ""
+		if gatewayInstance.GatewayInstance.WorkloadInstance != nil &&
+			gatewayInstance.GatewayInstance.WorkloadInstance.Name != nil {
+			workloadInstanceName = *gatewayInstance.GatewayInstance.WorkloadInstance.Name
+		}
+		age := ""
+		if gatewayInstance.GatewayInstance.Age != nil {
+			age = *gatewayInstance.GatewayInstance.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*gatewayInstance.GatewayInstance.Name, "\t",
-			*gatewayInstance.GatewayInstance.GatewayDefinition.Name, "\t",
-			*gatewayInstance.GatewayInstance.KubernetesRuntimeInstance.Name, "\t",
-			*gatewayInstance.GatewayInstance.WorkloadInstance.Name, "\t",
-			*gatewayInstance.GatewayInstance.Age,
+			gatewayDefinitionName, "\t",
+			kubernetesRuntimeInstanceName, "\t",
+			workloadInstanceName, "\t",
+			age,
 		)
 	}
 	writer.Flush()

--- a/cmd/tptctl/cmd/gateway_get_output.go
+++ b/cmd/tptctl/cmd/gateway_get_output.go
@@ -16,11 +16,10 @@ func outputGetv0DomainNamesCmd(
 	domainNames *[]config_v0.DomainNameConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t DOMAIN NAME DEFINITION\t DOMAIN NAME INSTANCE\t DOMAIN\t ZONE\t ADMIN EMAIL\t WORKLOAD INSTANCE\t AGE")
+	fmt.Fprintln(writer, "NAME\t DOMAIN NAME DEFINITION\t DOMAIN NAME INSTANCE\t DOMAIN\t ZONE\t ADMIN EMAIL\t WORKLOAD INSTANCE\t AGE")
 	for _, domainName := range *domainNames {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*domainName.DomainName.Name, "\t",
 			*domainName.DomainName.Name, "\t",
 			*domainName.DomainName.Name, "\t",
@@ -42,11 +41,10 @@ func outputGetv0DomainNameDefinitionsCmd(
 	domainNameDefinitions *[]config_v0.DomainNameDefinitionConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t DOMAIN\t ZONE\t ADMIN EMAIL\t AGE ")
+	fmt.Fprintln(writer, "NAME\t DOMAIN\t ZONE\t ADMIN EMAIL\t AGE ")
 	for _, domainNameDefinition := range *domainNameDefinitions {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*domainNameDefinition.DomainNameDefinition.Name, "\t",
 			*domainNameDefinition.DomainNameDefinition.Domain, "\t",
 			*domainNameDefinition.DomainNameDefinition.Zone, "\t",
@@ -65,11 +63,10 @@ func outputGetv0DomainNameInstancesCmd(
 	domainNameInstances *[]config_v0.DomainNameInstanceConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t DOMAIN NAME DEFINITION\t KUBERNETES RUNTIME INSTANCE\t WORKLOAD INSTANCE\t AGE")
+	fmt.Fprintln(writer, "NAME\t DOMAIN NAME DEFINITION\t KUBERNETES RUNTIME INSTANCE\t WORKLOAD INSTANCE\t AGE")
 	for _, domainNameInstance := range *domainNameInstances {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*domainNameInstance.DomainNameInstance.Name, "\t",
 			*domainNameInstance.DomainNameInstance.DomainNameDefinition.Name, "\t",
 			*domainNameInstance.DomainNameInstance.KubernetesRuntimeInstance.Name, "\t",
@@ -88,11 +85,10 @@ func outputGetv0GatewaysCmd(
 	gateways *[]config_v0.GatewayConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t GATEWAY DEFINITION\t GATEWAY INSTANCE\t HTTP PORTS\t TCP PORTS\t SUBDOMAIN\t KUBERNETES SERVICE NAME\t DOMAIN NAME DEFINITION\t KUBERNETES RUNTIME INSTANCE\t WORKLOAD INSTANCE\t AGE")
+	fmt.Fprintln(writer, "NAME\t GATEWAY DEFINITION\t GATEWAY INSTANCE\t HTTP PORTS\t TCP PORTS\t SUBDOMAIN\t KUBERNETES SERVICE NAME\t DOMAIN NAME DEFINITION\t KUBERNETES RUNTIME INSTANCE\t WORKLOAD INSTANCE\t AGE")
 	for _, gateway := range *gateways {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*gateway.Gateway.Name, "\t",
 			*gateway.Gateway.Name, "\t",
 			*gateway.Gateway.Name, "\t",
@@ -117,11 +113,10 @@ func outputGetv0GatewayDefinitionsCmd(
 	gatewayDefinitions *[]config_v0.GatewayDefinitionConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t HTTP PORTS\t TCP PORTS\t SUBDOMAIN\t KUBERNETES SERVICE NAME\t DOMAIN NAME DEFINITION\t AGE")
+	fmt.Fprintln(writer, "NAME\t HTTP PORTS\t TCP PORTS\t SUBDOMAIN\t KUBERNETES SERVICE NAME\t DOMAIN NAME DEFINITION\t AGE")
 	for _, gatewayDefinition := range *gatewayDefinitions {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*gatewayDefinition.GatewayDefinition.Name, "\t",
 			*gatewayDefinition.GatewayDefinition.HttpPorts, "\t",
 			*gatewayDefinition.GatewayDefinition.TcpPorts, "\t",
@@ -142,11 +137,10 @@ func outputGetv0GatewayInstancesCmd(
 	gatewayInstances *[]config_v0.GatewayInstanceConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t GATEWAY DEFINITION\t KUBERNETES RUNTIME INSTANCE\t WORKLOAD INSTANCE\t AGE")
+	fmt.Fprintln(writer, "NAME\t GATEWAY DEFINITION\t KUBERNETES RUNTIME INSTANCE\t WORKLOAD INSTANCE\t AGE")
 	for _, gatewayInstance := range *gatewayInstances {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*gatewayInstance.GatewayInstance.Name, "\t",
 			*gatewayInstance.GatewayInstance.GatewayDefinition.Name, "\t",
 			*gatewayInstance.GatewayInstance.KubernetesRuntimeInstance.Name, "\t",

--- a/cmd/tptctl/cmd/helm_workload_get_output.go
+++ b/cmd/tptctl/cmd/helm_workload_get_output.go
@@ -18,6 +18,19 @@ func outputGetv0HelmWorkloadsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t HELM WORKLOAD DEFINITION\t HELM WORKLOAD INSTANCE\t REPO\t CHART\t KUBERNETES RUNTIME INSTANCE\t STATUS\t AGE")
 	for _, helmWorkload := range *helmWorkloads {
+		kubernetesRuntimeInstanceName := ""
+		if helmWorkload.HelmWorkload.KubernetesRuntimeInstance != nil &&
+			helmWorkload.HelmWorkload.KubernetesRuntimeInstance.Name != nil {
+			kubernetesRuntimeInstanceName = *helmWorkload.HelmWorkload.KubernetesRuntimeInstance.Name
+		}
+		status := ""
+		if helmWorkload.HelmWorkload.Status != nil {
+			status = *helmWorkload.HelmWorkload.Status
+		}
+		age := ""
+		if helmWorkload.HelmWorkload.Age != nil {
+			age = *helmWorkload.HelmWorkload.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*helmWorkload.HelmWorkload.Name, "\t",
@@ -25,9 +38,9 @@ func outputGetv0HelmWorkloadsCmd(
 			*helmWorkload.HelmWorkload.Name, "\t",
 			*helmWorkload.HelmWorkload.Repo, "\t",
 			*helmWorkload.HelmWorkload.Chart, "\t",
-			*helmWorkload.HelmWorkload.KubernetesRuntimeInstance.Name, "\t",
-			*helmWorkload.HelmWorkload.Status, "\t",
-			*helmWorkload.HelmWorkload.Age,
+			kubernetesRuntimeInstanceName, "\t",
+			status, "\t",
+			age,
 		)
 	}
 	writer.Flush()
@@ -43,12 +56,16 @@ func outputGetv0HelmWorkloadDefinitionsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t REPO\t CHART\t AGE")
 	for _, helmWorkloadDefinition := range *helmWorkloadDefinitions {
+		age := ""
+		if helmWorkloadDefinition.HelmWorkloadDefinition.Age != nil {
+			age = *helmWorkloadDefinition.HelmWorkloadDefinition.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*helmWorkloadDefinition.HelmWorkloadDefinition.Name, "\t",
 			*helmWorkloadDefinition.HelmWorkloadDefinition.Repo, "\t",
 			*helmWorkloadDefinition.HelmWorkloadDefinition.Chart, "\t",
-			*helmWorkloadDefinition.HelmWorkloadDefinition.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -64,13 +81,31 @@ func outputGetv0HelmWorkloadInstancesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t HELM WORKLOAD DEFINITION\t KUBERNETES RUNTIME INSTANCE\t STATUS\t AGE")
 	for _, helmWorkloadInstance := range *helmWorkloadInstances {
+		helmWorkloadDefinitionName := ""
+		if helmWorkloadInstance.HelmWorkloadInstance.HelmWorkloadDefinition != nil &&
+			helmWorkloadInstance.HelmWorkloadInstance.HelmWorkloadDefinition.Name != nil {
+			helmWorkloadDefinitionName = *helmWorkloadInstance.HelmWorkloadInstance.HelmWorkloadDefinition.Name
+		}
+		kubernetesRuntimeInstanceName := ""
+		if helmWorkloadInstance.HelmWorkloadInstance.KubernetesRuntimeInstance != nil &&
+			helmWorkloadInstance.HelmWorkloadInstance.KubernetesRuntimeInstance.Name != nil {
+			kubernetesRuntimeInstanceName = *helmWorkloadInstance.HelmWorkloadInstance.KubernetesRuntimeInstance.Name
+		}
+		status := ""
+		if helmWorkloadInstance.HelmWorkloadInstance.Status != nil {
+			status = *helmWorkloadInstance.HelmWorkloadInstance.Status
+		}
+		age := ""
+		if helmWorkloadInstance.HelmWorkloadInstance.Age != nil {
+			age = *helmWorkloadInstance.HelmWorkloadInstance.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*helmWorkloadInstance.HelmWorkloadInstance.Name, "\t",
-			*helmWorkloadInstance.HelmWorkloadInstance.HelmWorkloadDefinition.Name, "\t",
-			*helmWorkloadInstance.HelmWorkloadInstance.KubernetesRuntimeInstance.Name, "\t",
-			*helmWorkloadInstance.HelmWorkloadInstance.Status, "\t",
-			*helmWorkloadInstance.HelmWorkloadInstance.Age,
+			helmWorkloadDefinitionName, "\t",
+			kubernetesRuntimeInstanceName, "\t",
+			status, "\t",
+			age,
 		)
 	}
 	writer.Flush()

--- a/cmd/tptctl/cmd/helm_workload_get_output.go
+++ b/cmd/tptctl/cmd/helm_workload_get_output.go
@@ -16,11 +16,10 @@ func outputGetv0HelmWorkloadsCmd(
 	helmWorkloads *[]config_v0.HelmWorkloadConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t HELM WORKLOAD DEFINITION\t HELM WORKLOAD INSTANCE\t REPO\t CHART\t KUBERNETES RUNTIME INSTANCE\t STATUS\t AGE")
+	fmt.Fprintln(writer, "NAME\t HELM WORKLOAD DEFINITION\t HELM WORKLOAD INSTANCE\t REPO\t CHART\t KUBERNETES RUNTIME INSTANCE\t STATUS\t AGE")
 	for _, helmWorkload := range *helmWorkloads {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*helmWorkload.HelmWorkload.Name, "\t",
 			*helmWorkload.HelmWorkload.Name, "\t",
 			*helmWorkload.HelmWorkload.Name, "\t",
@@ -42,11 +41,10 @@ func outputGetv0HelmWorkloadDefinitionsCmd(
 	helmWorkloadDefinitions *[]config_v0.HelmWorkloadDefinitionConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t REPO\t CHART\t AGE")
+	fmt.Fprintln(writer, "NAME\t REPO\t CHART\t AGE")
 	for _, helmWorkloadDefinition := range *helmWorkloadDefinitions {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*helmWorkloadDefinition.HelmWorkloadDefinition.Name, "\t",
 			*helmWorkloadDefinition.HelmWorkloadDefinition.Repo, "\t",
 			*helmWorkloadDefinition.HelmWorkloadDefinition.Chart, "\t",
@@ -64,11 +62,10 @@ func outputGetv0HelmWorkloadInstancesCmd(
 	helmWorkloadInstances *[]config_v0.HelmWorkloadInstanceConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t HELM WORKLOAD DEFINITION\t KUBERNETES RUNTIME INSTANCE\t STATUS\t AGE")
+	fmt.Fprintln(writer, "NAME\t HELM WORKLOAD DEFINITION\t KUBERNETES RUNTIME INSTANCE\t STATUS\t AGE")
 	for _, helmWorkloadInstance := range *helmWorkloadInstances {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*helmWorkloadInstance.HelmWorkloadInstance.Name, "\t",
 			*helmWorkloadInstance.HelmWorkloadInstance.HelmWorkloadDefinition.Name, "\t",
 			*helmWorkloadInstance.HelmWorkloadInstance.KubernetesRuntimeInstance.Name, "\t",

--- a/cmd/tptctl/cmd/kubernetes_runtime_get_output.go
+++ b/cmd/tptctl/cmd/kubernetes_runtime_get_output.go
@@ -22,6 +22,10 @@ func outputGetv0KubernetesRuntimesCmd(
 		if kubernetesRuntime.KubernetesRuntime.InfraProviderAccountName != nil {
 			infraProviderAcctName = *kubernetesRuntime.KubernetesRuntime.InfraProviderAccountName
 		}
+		age := ""
+		if kubernetesRuntime.KubernetesRuntime.Age != nil {
+			age = *kubernetesRuntime.KubernetesRuntime.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*kubernetesRuntime.KubernetesRuntime.Name, "\t",
@@ -33,7 +37,7 @@ func outputGetv0KubernetesRuntimesCmd(
 			*kubernetesRuntime.KubernetesRuntime.Location, "\t",
 			*kubernetesRuntime.KubernetesRuntime.DefaultRuntime, "\t",
 			*kubernetesRuntime.KubernetesRuntime.ForceDelete, "\t",
-			*kubernetesRuntime.KubernetesRuntime.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -53,13 +57,17 @@ func outputGetv0KubernetesRuntimeDefinitionsCmd(
 		if kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.InfraProviderAccountName != nil {
 			infraProviderAccountName = *kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.InfraProviderAccountName
 		}
+		age := ""
+		if kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.Age != nil {
+			age = *kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.Name, "\t",
 			*kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.InfraProvider, "\t",
 			*kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.HighAvailability, "\t",
 			infraProviderAccountName, "\t",
-			*kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -75,14 +83,23 @@ func outputGetv0KubernetesRuntimeInstancesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t KUBERNETES RUNTIME DEFINITION\t LOCATION\t DEFAULT RUNTIME\t FORCE DELETE\t AGE")
 	for _, kubernetesRuntimeInstance := range *kubernetesRuntimeInstances {
+		definitionName := ""
+		if kubernetesRuntimeInstance.KubernetesRuntimeInstance.KubernetesRuntimeDefinition != nil &&
+			kubernetesRuntimeInstance.KubernetesRuntimeInstance.KubernetesRuntimeDefinition.Name != nil {
+			definitionName = *kubernetesRuntimeInstance.KubernetesRuntimeInstance.KubernetesRuntimeDefinition.Name
+		}
+		age := ""
+		if kubernetesRuntimeInstance.KubernetesRuntimeInstance.Age != nil {
+			age = *kubernetesRuntimeInstance.KubernetesRuntimeInstance.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*kubernetesRuntimeInstance.KubernetesRuntimeInstance.Name, "\t",
-			*kubernetesRuntimeInstance.KubernetesRuntimeInstance.KubernetesRuntimeDefinition.Name, "\t",
+			definitionName, "\t",
 			*kubernetesRuntimeInstance.KubernetesRuntimeInstance.Location, "\t",
 			*kubernetesRuntimeInstance.KubernetesRuntimeInstance.DefaultRuntime, "\t",
 			*kubernetesRuntimeInstance.KubernetesRuntimeInstance.ForceDelete, "\t",
-			*kubernetesRuntimeInstance.KubernetesRuntimeInstance.Age,
+			age,
 		)
 	}
 	writer.Flush()

--- a/cmd/tptctl/cmd/kubernetes_runtime_get_output.go
+++ b/cmd/tptctl/cmd/kubernetes_runtime_get_output.go
@@ -16,7 +16,7 @@ func outputGetv0KubernetesRuntimesCmd(
 	kubernetesRuntimes *[]config_v0.KubernetesRuntimeConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t KUBERNETES RUNTIME DEFINITION\t KUBERNETES RUNTIME INSTANCE\t INFRA PROVIDER\t HIGH AVAILABILITY\t INFRA PROVIDER ACCOUNT\t LOCATION\t DEFAULT RUNTIME\t FORCE DELETE\t AGE")
+	fmt.Fprintln(writer, "NAME\t KUBERNETES RUNTIME DEFINITION\t KUBERNETES RUNTIME INSTANCE\t INFRA PROVIDER\t HIGH AVAILABILITY\t INFRA PROVIDER ACCOUNT\t LOCATION\t DEFAULT RUNTIME\t FORCE DELETE\t AGE")
 	for _, kubernetesRuntime := range *kubernetesRuntimes {
 		infraProviderAcctName := ""
 		if kubernetesRuntime.KubernetesRuntime.InfraProviderAccountName != nil {
@@ -24,7 +24,6 @@ func outputGetv0KubernetesRuntimesCmd(
 		}
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*kubernetesRuntime.KubernetesRuntime.Name, "\t",
 			*kubernetesRuntime.KubernetesRuntime.Name, "\t",
 			*kubernetesRuntime.KubernetesRuntime.Name, "\t",
@@ -48,15 +47,18 @@ func outputGetv0KubernetesRuntimeDefinitionsCmd(
 	kubernetesRuntimeDefinitions *[]config_v0.KubernetesRuntimeDefinitionConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t INFRA PROVIDER\t HIGH AVAILABILITY\t INFRA PROVIDER ACCOUNT\t AGE")
+	fmt.Fprintln(writer, "NAME\t INFRA PROVIDER\t HIGH AVAILABILITY\t INFRA PROVIDER ACCOUNT\t AGE")
 	for _, kubernetesRuntimeDefinition := range *kubernetesRuntimeDefinitions {
+		infraProviderAccountName := ""
+		if kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.InfraProviderAccountName != nil {
+			infraProviderAccountName = *kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.InfraProviderAccountName
+		}
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.Name, "\t",
 			*kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.InfraProvider, "\t",
 			*kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.HighAvailability, "\t",
-			*kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.InfraProviderAccountName, "\t",
+			infraProviderAccountName, "\t",
 			*kubernetesRuntimeDefinition.KubernetesRuntimeDefinition.Age,
 		)
 	}
@@ -71,11 +73,10 @@ func outputGetv0KubernetesRuntimeInstancesCmd(
 	kubernetesRuntimeInstances *[]config_v0.KubernetesRuntimeInstanceConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t KUBERNETES RUNTIME DEFINITION\t LOCATION\t DEFAULT RUNTIME\t FORCE DELETE\t AGE")
+	fmt.Fprintln(writer, "NAME\t KUBERNETES RUNTIME DEFINITION\t LOCATION\t DEFAULT RUNTIME\t FORCE DELETE\t AGE")
 	for _, kubernetesRuntimeInstance := range *kubernetesRuntimeInstances {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*kubernetesRuntimeInstance.KubernetesRuntimeInstance.Name, "\t",
 			*kubernetesRuntimeInstance.KubernetesRuntimeInstance.KubernetesRuntimeDefinition.Name, "\t",
 			*kubernetesRuntimeInstance.KubernetesRuntimeInstance.Location, "\t",

--- a/cmd/tptctl/cmd/module_get_output.go
+++ b/cmd/tptctl/cmd/module_get_output.go
@@ -18,11 +18,15 @@ func outputGetv0ModuleApisCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t CORE MODULE\t AGE")
 	for _, moduleApi := range *moduleApis {
+		age := ""
+		if moduleApi.ModuleApi.Age != nil {
+			age = *moduleApi.ModuleApi.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*moduleApi.ModuleApi.Name, "\t",
 			*moduleApi.ModuleApi.Core, "\t",
-			*moduleApi.ModuleApi.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -38,11 +42,20 @@ func outputGetv0ModuleApiRoutesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "PATH\t MODULE API\t AGE")
 	for _, moduleApiRoute := range *moduleApiRoutes {
+		moduleApiName := ""
+		if moduleApiRoute.ModuleApiRoute.ModuleApi != nil &&
+			moduleApiRoute.ModuleApiRoute.ModuleApi.Name != nil {
+			moduleApiName = *moduleApiRoute.ModuleApiRoute.ModuleApi.Name
+		}
+		age := ""
+		if moduleApiRoute.ModuleApiRoute.Age != nil {
+			age = *moduleApiRoute.ModuleApiRoute.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*moduleApiRoute.ModuleApiRoute.Path, "\t",
-			*moduleApiRoute.ModuleApiRoute.ModuleApi.Name, "\t",
-			*moduleApiRoute.ModuleApiRoute.Age,
+			moduleApiName, "\t",
+			age,
 		)
 	}
 	writer.Flush()
@@ -58,11 +71,20 @@ func outputGetv0ModuleControllersCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t MODULE API\t AGE")
 	for _, moduleController := range *moduleControllers {
+		moduleApiName := ""
+		if moduleController.ModuleController.ModuleApi != nil &&
+			moduleController.ModuleController.ModuleApi.Name != nil {
+			moduleApiName = *moduleController.ModuleController.ModuleApi.Name
+		}
+		age := ""
+		if moduleController.ModuleController.Age != nil {
+			age = *moduleController.ModuleController.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*moduleController.ModuleController.Name, "\t",
-			*moduleController.ModuleController.ModuleApi.Name, "\t",
-			*moduleController.ModuleController.Age,
+			moduleApiName, "\t",
+			age,
 		)
 	}
 	writer.Flush()
@@ -78,18 +100,32 @@ func outputGetv0ModuleObjectsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t VERSION\t DESCRIPTION\t MODULE CONTROLLER\t MODULE API\t AGE")
 	for _, moduleObject := range *moduleObjects {
+		description := ""
+		if moduleObject.ModuleObject.Description != nil {
+			description = *moduleObject.ModuleObject.Description
+		}
 		moduleControllerName := ""
-		if moduleObject.ModuleObject.ModuleController != nil {
+		if moduleObject.ModuleObject.ModuleController != nil &&
+			moduleObject.ModuleObject.ModuleController.Name != nil {
 			moduleControllerName = *moduleObject.ModuleObject.ModuleController.Name
+		}
+		moduleApiName := ""
+		if moduleObject.ModuleObject.ModuleApi != nil &&
+			moduleObject.ModuleObject.ModuleApi.Name != nil {
+			moduleApiName = *moduleObject.ModuleObject.ModuleApi.Name
+		}
+		age := ""
+		if moduleObject.ModuleObject.Age != nil {
+			age = *moduleObject.ModuleObject.Age
 		}
 		fmt.Fprintln(
 			writer,
 			*moduleObject.ModuleObject.Name, "\t",
 			*moduleObject.ModuleObject.Version, "\t",
-			*moduleObject.ModuleObject.Description, "\t",
+			description, "\t",
 			moduleControllerName, "\t",
-			*moduleObject.ModuleObject.ModuleApi.Name, "\t",
-			*moduleObject.ModuleObject.Age,
+			moduleApiName, "\t",
+			age,
 		)
 	}
 	writer.Flush()

--- a/cmd/tptctl/cmd/module_get_output.go
+++ b/cmd/tptctl/cmd/module_get_output.go
@@ -16,11 +16,10 @@ func outputGetv0ModuleApisCmd(
 	moduleApis *[]config_v0.ModuleApiConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t CORE MODULE\t AGE")
+	fmt.Fprintln(writer, "NAME\t CORE MODULE\t AGE")
 	for _, moduleApi := range *moduleApis {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*moduleApi.ModuleApi.Name, "\t",
 			*moduleApi.ModuleApi.Core, "\t",
 			*moduleApi.ModuleApi.Age,
@@ -37,11 +36,10 @@ func outputGetv0ModuleApiRoutesCmd(
 	moduleApiRoutes *[]config_v0.ModuleApiRouteConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t PATH\t MODULE API\t AGE")
+	fmt.Fprintln(writer, "PATH\t MODULE API\t AGE")
 	for _, moduleApiRoute := range *moduleApiRoutes {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*moduleApiRoute.ModuleApiRoute.Path, "\t",
 			*moduleApiRoute.ModuleApiRoute.ModuleApi.Name, "\t",
 			*moduleApiRoute.ModuleApiRoute.Age,
@@ -58,11 +56,10 @@ func outputGetv0ModuleControllersCmd(
 	moduleControllers *[]config_v0.ModuleControllerConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t MODULE API\t AGE")
+	fmt.Fprintln(writer, "NAME\t MODULE API\t AGE")
 	for _, moduleController := range *moduleControllers {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*moduleController.ModuleController.Name, "\t",
 			*moduleController.ModuleController.ModuleApi.Name, "\t",
 			*moduleController.ModuleController.Age,
@@ -79,7 +76,7 @@ func outputGetv0ModuleObjectsCmd(
 	moduleObjects *[]config_v0.ModuleObjectConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t VERSION\t DESCRIPTION\t MODULE CONTROLLER\t MODULE API\t AGE")
+	fmt.Fprintln(writer, "NAME\t VERSION\t DESCRIPTION\t MODULE CONTROLLER\t MODULE API\t AGE")
 	for _, moduleObject := range *moduleObjects {
 		moduleControllerName := ""
 		if moduleObject.ModuleObject.ModuleController != nil {
@@ -87,7 +84,6 @@ func outputGetv0ModuleObjectsCmd(
 		}
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*moduleObject.ModuleObject.Name, "\t",
 			*moduleObject.ModuleObject.Version, "\t",
 			*moduleObject.ModuleObject.Description, "\t",

--- a/cmd/tptctl/cmd/observability_get_output.go
+++ b/cmd/tptctl/cmd/observability_get_output.go
@@ -18,15 +18,24 @@ func outputGetv0ObservabilityStacksCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t OBSERVABILITY STACK DEFINITION\t OBSERVABILITY STACK INSTANCE\t KUBERNETES RUNTIME INSTANCE\t METRICS ENABLED\t LOGGING ENABLED\t AGE")
 	for _, observabilityStack := range *observabilityStacks {
+		kubernetesRuntimeInstanceName := ""
+		if observabilityStack.ObservabilityStack.KubernetesRuntimeInstance != nil &&
+			observabilityStack.ObservabilityStack.KubernetesRuntimeInstance.Name != nil {
+			kubernetesRuntimeInstanceName = *observabilityStack.ObservabilityStack.KubernetesRuntimeInstance.Name
+		}
+		age := ""
+		if observabilityStack.ObservabilityStack.Age != nil {
+			age = *observabilityStack.ObservabilityStack.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*observabilityStack.ObservabilityStack.Name, "\t",
 			*observabilityStack.ObservabilityStack.Name, "\t",
 			*observabilityStack.ObservabilityStack.Name, "\t",
-			*observabilityStack.ObservabilityStack.KubernetesRuntimeInstance.Name, "\t",
+			kubernetesRuntimeInstanceName, "\t",
 			*observabilityStack.ObservabilityStack.MetricsEnabled, "\t",
 			*observabilityStack.ObservabilityStack.LoggingEnabled, "\t",
-			*observabilityStack.ObservabilityStack.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -42,10 +51,14 @@ func outputGetv0ObservabilityStackDefinitionsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t AGE")
 	for _, observabilityStackDefinition := range *observabilityStackDefinitions {
+		age := ""
+		if observabilityStackDefinition.ObservabilityStackDefinition.Age != nil {
+			age = *observabilityStackDefinition.ObservabilityStackDefinition.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*observabilityStackDefinition.ObservabilityStackDefinition.Name, "\t",
-			*observabilityStackDefinition.ObservabilityStackDefinition.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -61,14 +74,28 @@ func outputGetv0ObservabilityStackInstancesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t OBSERVABILITY STACK DEFINITION\t KUBERNETES RUNTIME INSTANCE\t METRICS ENABLED\t LOGGING ENABLED\t AGE")
 	for _, observabilityStackInstance := range *observabilityStackInstances {
+		observabilityStackDefinitionName := ""
+		if observabilityStackInstance.ObservabilityStackInstance.ObservabilityStackDefinition != nil &&
+			observabilityStackInstance.ObservabilityStackInstance.ObservabilityStackDefinition.Name != nil {
+			observabilityStackDefinitionName = *observabilityStackInstance.ObservabilityStackInstance.ObservabilityStackDefinition.Name
+		}
+		kubernetesRuntimeInstanceName := ""
+		if observabilityStackInstance.ObservabilityStackInstance.KubernetesRuntimeInstance != nil &&
+			observabilityStackInstance.ObservabilityStackInstance.KubernetesRuntimeInstance.Name != nil {
+			kubernetesRuntimeInstanceName = *observabilityStackInstance.ObservabilityStackInstance.KubernetesRuntimeInstance.Name
+		}
+		age := ""
+		if observabilityStackInstance.ObservabilityStackInstance.Age != nil {
+			age = *observabilityStackInstance.ObservabilityStackInstance.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*observabilityStackInstance.ObservabilityStackInstance.Name, "\t",
-			*observabilityStackInstance.ObservabilityStackInstance.ObservabilityStackDefinition.Name, "\t",
-			*observabilityStackInstance.ObservabilityStackInstance.KubernetesRuntimeInstance.Name, "\t",
+			observabilityStackDefinitionName, "\t",
+			kubernetesRuntimeInstanceName, "\t",
 			*observabilityStackInstance.ObservabilityStackInstance.MetricsEnabled, "\t",
 			*observabilityStackInstance.ObservabilityStackInstance.LoggingEnabled, "\t",
-			*observabilityStackInstance.ObservabilityStackInstance.Age,
+			age,
 		)
 	}
 	writer.Flush()

--- a/cmd/tptctl/cmd/observability_get_output.go
+++ b/cmd/tptctl/cmd/observability_get_output.go
@@ -16,11 +16,10 @@ func outputGetv0ObservabilityStacksCmd(
 	observabilityStacks *[]config_v0.ObservabilityStackConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t OBSERVABILITY STACK DEFINITION\t OBSERVABILITY STACK INSTANCE\t KUBERNETES RUNTIME INSTANCE\t METRICS ENABLED\t LOGGING ENABLED\t AGE")
+	fmt.Fprintln(writer, "NAME\t OBSERVABILITY STACK DEFINITION\t OBSERVABILITY STACK INSTANCE\t KUBERNETES RUNTIME INSTANCE\t METRICS ENABLED\t LOGGING ENABLED\t AGE")
 	for _, observabilityStack := range *observabilityStacks {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*observabilityStack.ObservabilityStack.Name, "\t",
 			*observabilityStack.ObservabilityStack.Name, "\t",
 			*observabilityStack.ObservabilityStack.Name, "\t",
@@ -41,11 +40,10 @@ func outputGetv0ObservabilityStackDefinitionsCmd(
 	observabilityStackDefinitions *[]config_v0.ObservabilityStackDefinitionConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t AGE")
+	fmt.Fprintln(writer, "NAME\t AGE")
 	for _, observabilityStackDefinition := range *observabilityStackDefinitions {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*observabilityStackDefinition.ObservabilityStackDefinition.Name, "\t",
 			*observabilityStackDefinition.ObservabilityStackDefinition.Age,
 		)
@@ -61,11 +59,10 @@ func outputGetv0ObservabilityStackInstancesCmd(
 	observabilityStackInstances *[]config_v0.ObservabilityStackInstanceConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t OBSERVABILITY STACK DEFINITION\t KUBERNETES RUNTIME INSTANCE\t METRICS ENABLED\t LOGGING ENABLED\t AGE")
+	fmt.Fprintln(writer, "NAME\t OBSERVABILITY STACK DEFINITION\t KUBERNETES RUNTIME INSTANCE\t METRICS ENABLED\t LOGGING ENABLED\t AGE")
 	for _, observabilityStackInstance := range *observabilityStackInstances {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*observabilityStackInstance.ObservabilityStackInstance.Name, "\t",
 			*observabilityStackInstance.ObservabilityStackInstance.ObservabilityStackDefinition.Name, "\t",
 			*observabilityStackInstance.ObservabilityStackInstance.KubernetesRuntimeInstance.Name, "\t",

--- a/cmd/tptctl/cmd/oci_get_output.go
+++ b/cmd/tptctl/cmd/oci_get_output.go
@@ -18,6 +18,10 @@ func outputGetv0OciAccountsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t USER OCID\t TENANCY OCID\t DEFAULT ACCOUNT\t DEFAULT REGION\t AGE")
 	for _, ociAccount := range *ociAccounts {
+		age := ""
+		if ociAccount.OciAccount.Age != nil {
+			age = *ociAccount.OciAccount.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*ociAccount.OciAccount.Name, "\t",
@@ -25,7 +29,7 @@ func outputGetv0OciAccountsCmd(
 			*ociAccount.OciAccount.TenancyOCID, "\t",
 			*ociAccount.OciAccount.DefaultAccount, "\t",
 			*ociAccount.OciAccount.DefaultRegion, "\t",
-			*ociAccount.OciAccount.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -41,14 +45,22 @@ func outputGetv0OciOkeKubernetesRuntimesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t ACCOUNT NAME\t WORKER NODE SHAPE\t WORKER NODE INITIAL COUNT\t REGION\t AGE")
 	for _, ociOkeKubernetesRuntime := range *ociOkeKubernetesRuntimes {
+		region := ""
+		if ociOkeKubernetesRuntime.OciOkeKubernetesRuntime.Region != nil {
+			region = *ociOkeKubernetesRuntime.OciOkeKubernetesRuntime.Region
+		}
+		age := ""
+		if ociOkeKubernetesRuntime.OciOkeKubernetesRuntime.Age != nil {
+			age = *ociOkeKubernetesRuntime.OciOkeKubernetesRuntime.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*ociOkeKubernetesRuntime.OciOkeKubernetesRuntime.Name, "\t",
 			*ociOkeKubernetesRuntime.OciOkeKubernetesRuntime.OciAccountName, "\t",
 			*ociOkeKubernetesRuntime.OciOkeKubernetesRuntime.WorkerNodeShape, "\t",
 			*ociOkeKubernetesRuntime.OciOkeKubernetesRuntime.WorkerNodeInitialCount, "\t",
-			*ociOkeKubernetesRuntime.OciOkeKubernetesRuntime.Region, "\t",
-			*ociOkeKubernetesRuntime.OciOkeKubernetesRuntime.Age,
+			region, "\t",
+			age,
 		)
 	}
 	writer.Flush()
@@ -64,13 +76,17 @@ func outputGetv0OciOkeKubernetesRuntimeDefinitionsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t OCI ACCOUNT NAME\t WORKER NODE SHAPE\t WORKER NODE INITIAL COUNT\t AGE")
 	for _, ociOkeKubernetesRuntimeDefinition := range *ociOkeKubernetesRuntimeDefinitions {
+		age := ""
+		if ociOkeKubernetesRuntimeDefinition.OciOkeKubernetesRuntimeDefinition.Age != nil {
+			age = *ociOkeKubernetesRuntimeDefinition.OciOkeKubernetesRuntimeDefinition.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*ociOkeKubernetesRuntimeDefinition.OciOkeKubernetesRuntimeDefinition.Name, "\t",
 			*ociOkeKubernetesRuntimeDefinition.OciOkeKubernetesRuntimeDefinition.OciAccountName, "\t",
 			*ociOkeKubernetesRuntimeDefinition.OciOkeKubernetesRuntimeDefinition.WorkerNodeShape, "\t",
 			*ociOkeKubernetesRuntimeDefinition.OciOkeKubernetesRuntimeDefinition.WorkerNodeInitialCount, "\t",
-			*ociOkeKubernetesRuntimeDefinition.OciOkeKubernetesRuntimeDefinition.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -86,12 +102,25 @@ func outputGetv0OciOkeKubernetesRuntimeInstancesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t OCI OKE KUBERNETES RUNTIME DEFINITION\t REGION\t AGE")
 	for _, ociOkeKubernetesRuntimeInstance := range *ociOkeKubernetesRuntimeInstances {
+		ociOkeDefinitionName := ""
+		if ociOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeDefinition != nil &&
+			ociOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeDefinition.Name != nil {
+			ociOkeDefinitionName = *ociOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeDefinition.Name
+		}
+		region := ""
+		if ociOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeInstance.Region != nil {
+			region = *ociOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeInstance.Region
+		}
+		age := ""
+		if ociOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeInstance.Age != nil {
+			age = *ociOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeInstance.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*ociOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeInstance.Name, "\t",
-			*ociOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeDefinition.Name, "\t",
-			*ociOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeInstance.Region, "\t",
-			*ociOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeInstance.Age,
+			ociOkeDefinitionName, "\t",
+			region, "\t",
+			age,
 		)
 	}
 	writer.Flush()

--- a/cmd/tptctl/cmd/oci_get_output.go
+++ b/cmd/tptctl/cmd/oci_get_output.go
@@ -16,11 +16,10 @@ func outputGetv0OciAccountsCmd(
 	ociAccounts *[]config_v0.OciAccountConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t USER OCID\t TENANCY OCID\t DEFAULT ACCOUNT\t DEFAULT REGION\t AGE")
+	fmt.Fprintln(writer, "NAME\t USER OCID\t TENANCY OCID\t DEFAULT ACCOUNT\t DEFAULT REGION\t AGE")
 	for _, ociAccount := range *ociAccounts {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*ociAccount.OciAccount.Name, "\t",
 			*ociAccount.OciAccount.UserOCID, "\t",
 			*ociAccount.OciAccount.TenancyOCID, "\t",
@@ -40,11 +39,10 @@ func outputGetv0OciOkeKubernetesRuntimesCmd(
 	ociOkeKubernetesRuntimes *[]config_v0.OciOkeKubernetesRuntimeConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t ACCOUNT NAME\t WORKER NODE SHAPE\t WORKER NODE INITIAL COUNT\t REGION\t AGE")
+	fmt.Fprintln(writer, "NAME\t ACCOUNT NAME\t WORKER NODE SHAPE\t WORKER NODE INITIAL COUNT\t REGION\t AGE")
 	for _, ociOkeKubernetesRuntime := range *ociOkeKubernetesRuntimes {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*ociOkeKubernetesRuntime.OciOkeKubernetesRuntime.Name, "\t",
 			*ociOkeKubernetesRuntime.OciOkeKubernetesRuntime.OciAccountName, "\t",
 			*ociOkeKubernetesRuntime.OciOkeKubernetesRuntime.WorkerNodeShape, "\t",
@@ -64,11 +62,10 @@ func outputGetv0OciOkeKubernetesRuntimeDefinitionsCmd(
 	ociOkeKubernetesRuntimeDefinitions *[]config_v0.OciOkeKubernetesRuntimeDefinitionConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t OCI ACCOUNT NAME\t WORKER NODE SHAPE\t WORKER NODE INITIAL COUNT\t AGE")
+	fmt.Fprintln(writer, "NAME\t OCI ACCOUNT NAME\t WORKER NODE SHAPE\t WORKER NODE INITIAL COUNT\t AGE")
 	for _, ociOkeKubernetesRuntimeDefinition := range *ociOkeKubernetesRuntimeDefinitions {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*ociOkeKubernetesRuntimeDefinition.OciOkeKubernetesRuntimeDefinition.Name, "\t",
 			*ociOkeKubernetesRuntimeDefinition.OciOkeKubernetesRuntimeDefinition.OciAccountName, "\t",
 			*ociOkeKubernetesRuntimeDefinition.OciOkeKubernetesRuntimeDefinition.WorkerNodeShape, "\t",
@@ -87,11 +84,10 @@ func outputGetv0OciOkeKubernetesRuntimeInstancesCmd(
 	ociOkeKubernetesRuntimeInstances *[]config_v0.OciOkeKubernetesRuntimeInstanceConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t OCI OKE KUBERNETES RUNTIME DEFINITION\t REGION\t AGE")
+	fmt.Fprintln(writer, "NAME\t OCI OKE KUBERNETES RUNTIME DEFINITION\t REGION\t AGE")
 	for _, ociOkeKubernetesRuntimeInstance := range *ociOkeKubernetesRuntimeInstances {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*ociOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeInstance.Name, "\t",
 			*ociOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeDefinition.Name, "\t",
 			*ociOkeKubernetesRuntimeInstance.OciOkeKubernetesRuntimeInstance.Region, "\t",

--- a/cmd/tptctl/cmd/secret_get_output.go
+++ b/cmd/tptctl/cmd/secret_get_output.go
@@ -18,15 +18,34 @@ func outputGetv0SecretsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t SECRET DEFINITION\t SECRET INSTANCE\t WORKLOAD INSTANCE\t HELM WORKLOAD INSTANCE\t KUBERNETES RUNTIME INSTANCE\t AGE")
 	for _, secret := range *secrets {
+		workloadInstanceName := ""
+		if secret.Secret.WorkloadInstance != nil &&
+			secret.Secret.WorkloadInstance.Name != nil {
+			workloadInstanceName = *secret.Secret.WorkloadInstance.Name
+		}
+		helmWorkloadInstanceName := ""
+		if secret.Secret.HelmWorkloadInstance != nil &&
+			secret.Secret.HelmWorkloadInstance.Name != nil {
+			helmWorkloadInstanceName = *secret.Secret.HelmWorkloadInstance.Name
+		}
+		kubernetesRuntimeInstanceName := ""
+		if secret.Secret.KubernetesRuntimeInstance != nil &&
+			secret.Secret.KubernetesRuntimeInstance.Name != nil {
+			kubernetesRuntimeInstanceName = *secret.Secret.KubernetesRuntimeInstance.Name
+		}
+		age := ""
+		if secret.Secret.Age != nil {
+			age = *secret.Secret.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*secret.Secret.Name, "\t",
 			*secret.Secret.Name, "\t",
 			*secret.Secret.Name, "\t",
-			*secret.Secret.WorkloadInstance.Name, "\t",
-			*secret.Secret.HelmWorkloadInstance.Name, "\t",
-			*secret.Secret.KubernetesRuntimeInstance.Name, "\t",
-			*secret.Secret.Age,
+			workloadInstanceName, "\t",
+			helmWorkloadInstanceName, "\t",
+			kubernetesRuntimeInstanceName, "\t",
+			age,
 		)
 	}
 	writer.Flush()
@@ -42,10 +61,14 @@ func outputGetv0SecretDefinitionsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t AGE")
 	for _, secretDefinition := range *secretDefinitions {
+		age := ""
+		if secretDefinition.SecretDefinition.Age != nil {
+			age = *secretDefinition.SecretDefinition.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*secretDefinition.SecretDefinition.Name, "\t",
-			*secretDefinition.SecretDefinition.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -61,14 +84,38 @@ func outputGetv0SecretInstancesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t SECRET DEFINITION\t WORKLOAD INSTANCE\t HELM WORKLOAD INSTANCE\t KUBERNETES RUNTIME INSTANCE\t AGE")
 	for _, secretInstance := range *secretInstances {
+		secretDefinitionName := ""
+		if secretInstance.SecretInstance.SecretDefinition != nil &&
+			secretInstance.SecretInstance.SecretDefinition.Name != nil {
+			secretDefinitionName = *secretInstance.SecretInstance.SecretDefinition.Name
+		}
+		workloadInstanceName := ""
+		if secretInstance.SecretInstance.WorkloadInstance != nil &&
+			secretInstance.SecretInstance.WorkloadInstance.Name != nil {
+			workloadInstanceName = *secretInstance.SecretInstance.WorkloadInstance.Name
+		}
+		helmWorkloadInstanceName := ""
+		if secretInstance.SecretInstance.HelmWorkloadInstance != nil &&
+			secretInstance.SecretInstance.HelmWorkloadInstance.Name != nil {
+			helmWorkloadInstanceName = *secretInstance.SecretInstance.HelmWorkloadInstance.Name
+		}
+		kubernetesRuntimeInstanceName := ""
+		if secretInstance.SecretInstance.KubernetesRuntimeInstance != nil &&
+			secretInstance.SecretInstance.KubernetesRuntimeInstance.Name != nil {
+			kubernetesRuntimeInstanceName = *secretInstance.SecretInstance.KubernetesRuntimeInstance.Name
+		}
+		age := ""
+		if secretInstance.SecretInstance.Age != nil {
+			age = *secretInstance.SecretInstance.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*secretInstance.SecretInstance.Name, "\t",
-			*secretInstance.SecretInstance.SecretDefinition.Name, "\t",
-			*secretInstance.SecretInstance.WorkloadInstance.Name, "\t",
-			*secretInstance.SecretInstance.HelmWorkloadInstance.Name, "\t",
-			*secretInstance.SecretInstance.KubernetesRuntimeInstance.Name, "\t",
-			*secretInstance.SecretInstance.Age,
+			secretDefinitionName, "\t",
+			workloadInstanceName, "\t",
+			helmWorkloadInstanceName, "\t",
+			kubernetesRuntimeInstanceName, "\t",
+			age,
 		)
 	}
 	writer.Flush()

--- a/cmd/tptctl/cmd/secret_get_output.go
+++ b/cmd/tptctl/cmd/secret_get_output.go
@@ -16,11 +16,10 @@ func outputGetv0SecretsCmd(
 	secrets *[]config_v0.SecretConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t SECRET DEFINITION\t SECRET INSTANCE\t WORKLOAD INSTANCE\t HELM WORKLOAD INSTANCE\t KUBERNETES RUNTIME INSTANCE\t AGE")
+	fmt.Fprintln(writer, "NAME\t SECRET DEFINITION\t SECRET INSTANCE\t WORKLOAD INSTANCE\t HELM WORKLOAD INSTANCE\t KUBERNETES RUNTIME INSTANCE\t AGE")
 	for _, secret := range *secrets {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*secret.Secret.Name, "\t",
 			*secret.Secret.Name, "\t",
 			*secret.Secret.Name, "\t",
@@ -41,11 +40,10 @@ func outputGetv0SecretDefinitionsCmd(
 	secretDefinitions *[]config_v0.SecretDefinitionConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t AGE")
+	fmt.Fprintln(writer, "NAME\t AGE")
 	for _, secretDefinition := range *secretDefinitions {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*secretDefinition.SecretDefinition.Name, "\t",
 			*secretDefinition.SecretDefinition.Age,
 		)
@@ -61,11 +59,10 @@ func outputGetv0SecretInstancesCmd(
 	secretInstances *[]config_v0.SecretInstanceConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t SECRET DEFINITION\t WORKLOAD INSTANCE\t HELM WORKLOAD INSTANCE\t KUBERNETES RUNTIME INSTANCE\t AGE")
+	fmt.Fprintln(writer, "NAME\t SECRET DEFINITION\t WORKLOAD INSTANCE\t HELM WORKLOAD INSTANCE\t KUBERNETES RUNTIME INSTANCE\t AGE")
 	for _, secretInstance := range *secretInstances {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*secretInstance.SecretInstance.Name, "\t",
 			*secretInstance.SecretInstance.SecretDefinition.Name, "\t",
 			*secretInstance.SecretInstance.WorkloadInstance.Name, "\t",

--- a/cmd/tptctl/cmd/terraform_get_output.go
+++ b/cmd/tptctl/cmd/terraform_get_output.go
@@ -16,11 +16,10 @@ func outputGetv0TerraformsCmd(
 	terraforms *[]config_v0.TerraformConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t TERRAFORM DEFINITION\t TERRAFORM INSTANCE\t AWS ACCOUNT\t STATUS\t AGE")
+	fmt.Fprintln(writer, "NAME\t TERRAFORM DEFINITION\t TERRAFORM INSTANCE\t AWS ACCOUNT\t STATUS\t AGE")
 	for _, terraform := range *terraforms {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*terraform.Terraform.Name, "\t",
 			*terraform.Terraform.Name, "\t",
 			*terraform.Terraform.Name, "\t",
@@ -40,11 +39,10 @@ func outputGetv0TerraformDefinitionsCmd(
 	terraformDefinitions *[]config_v0.TerraformDefinitionConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t AGE")
+	fmt.Fprintln(writer, "NAME\t AGE")
 	for _, terraformDefinition := range *terraformDefinitions {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*terraformDefinition.TerraformDefinition.Name, "\t",
 			*terraformDefinition.TerraformDefinition.Age,
 		)
@@ -60,11 +58,10 @@ func outputGetv0TerraformInstancesCmd(
 	terraformInstances *[]config_v0.TerraformInstanceConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t TERRAFORM DEFINITION\t AWS ACCOUNT NAME\t STATUS\t AGE")
+	fmt.Fprintln(writer, "NAME\t TERRAFORM DEFINITION\t AWS ACCOUNT NAME\t STATUS\t AGE")
 	for _, terraformInstance := range *terraformInstances {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*terraformInstance.TerraformInstance.Name, "\t",
 			*terraformInstance.TerraformInstance.TerraformDefinition.Name, "\t",
 			*terraformInstance.TerraformInstance.AwsAccount.Name, "\t",

--- a/cmd/tptctl/cmd/terraform_get_output.go
+++ b/cmd/tptctl/cmd/terraform_get_output.go
@@ -18,14 +18,27 @@ func outputGetv0TerraformsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t TERRAFORM DEFINITION\t TERRAFORM INSTANCE\t AWS ACCOUNT\t STATUS\t AGE")
 	for _, terraform := range *terraforms {
+		awsAccountName := ""
+		if terraform.Terraform.AwsAccount != nil &&
+			terraform.Terraform.AwsAccount.Name != nil {
+			awsAccountName = *terraform.Terraform.AwsAccount.Name
+		}
+		status := ""
+		if terraform.Terraform.Status != nil {
+			status = *terraform.Terraform.Status
+		}
+		age := ""
+		if terraform.Terraform.Age != nil {
+			age = *terraform.Terraform.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*terraform.Terraform.Name, "\t",
 			*terraform.Terraform.Name, "\t",
 			*terraform.Terraform.Name, "\t",
-			*terraform.Terraform.AwsAccount.Name, "\t",
-			*terraform.Terraform.Status, "\t",
-			*terraform.Terraform.Age,
+			awsAccountName, "\t",
+			status, "\t",
+			age,
 		)
 	}
 	writer.Flush()
@@ -41,10 +54,14 @@ func outputGetv0TerraformDefinitionsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t AGE")
 	for _, terraformDefinition := range *terraformDefinitions {
+		age := ""
+		if terraformDefinition.TerraformDefinition.Age != nil {
+			age = *terraformDefinition.TerraformDefinition.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*terraformDefinition.TerraformDefinition.Name, "\t",
-			*terraformDefinition.TerraformDefinition.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -60,13 +77,31 @@ func outputGetv0TerraformInstancesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t TERRAFORM DEFINITION\t AWS ACCOUNT NAME\t STATUS\t AGE")
 	for _, terraformInstance := range *terraformInstances {
+		terraformDefinitionName := ""
+		if terraformInstance.TerraformInstance.TerraformDefinition != nil &&
+			terraformInstance.TerraformInstance.TerraformDefinition.Name != nil {
+			terraformDefinitionName = *terraformInstance.TerraformInstance.TerraformDefinition.Name
+		}
+		awsAccountName := ""
+		if terraformInstance.TerraformInstance.AwsAccount != nil &&
+			terraformInstance.TerraformInstance.AwsAccount.Name != nil {
+			awsAccountName = *terraformInstance.TerraformInstance.AwsAccount.Name
+		}
+		status := ""
+		if terraformInstance.TerraformInstance.Status != nil {
+			status = *terraformInstance.TerraformInstance.Status
+		}
+		age := ""
+		if terraformInstance.TerraformInstance.Age != nil {
+			age = *terraformInstance.TerraformInstance.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*terraformInstance.TerraformInstance.Name, "\t",
-			*terraformInstance.TerraformInstance.TerraformDefinition.Name, "\t",
-			*terraformInstance.TerraformInstance.AwsAccount.Name, "\t",
-			*terraformInstance.TerraformInstance.Status, "\t",
-			*terraformInstance.TerraformInstance.Age,
+			terraformDefinitionName, "\t",
+			awsAccountName, "\t",
+			status, "\t",
+			age,
 		)
 	}
 	writer.Flush()

--- a/cmd/tptctl/cmd/workload_get_output.go
+++ b/cmd/tptctl/cmd/workload_get_output.go
@@ -18,14 +18,27 @@ func outputGetv0WorkloadsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t WORKLOAD DEFINITION\t WORKLOAD INSTANCE\t KUBERNETES RUNTIME INSTANCE\t STATUS\t AGE")
 	for _, workload := range *workloads {
+		kubernetesRuntimeInstanceName := ""
+		if workload.Workload.KubernetesRuntimeInstance != nil &&
+			workload.Workload.KubernetesRuntimeInstance.Name != nil {
+			kubernetesRuntimeInstanceName = *workload.Workload.KubernetesRuntimeInstance.Name
+		}
+		status := ""
+		if workload.Workload.Status != nil {
+			status = *workload.Workload.Status
+		}
+		age := ""
+		if workload.Workload.Age != nil {
+			age = *workload.Workload.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*workload.Workload.Name, "\t",
 			*workload.Workload.Name, "\t",
 			*workload.Workload.Name, "\t",
-			*workload.Workload.KubernetesRuntimeInstance.Name, "\t",
-			*workload.Workload.Status, "\t",
-			*workload.Workload.Age,
+			kubernetesRuntimeInstanceName, "\t",
+			status, "\t",
+			age,
 		)
 	}
 	writer.Flush()
@@ -41,10 +54,14 @@ func outputGetv0WorkloadDefinitionsCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t AGE")
 	for _, workloadDefinition := range *workloadDefinitions {
+		age := ""
+		if workloadDefinition.WorkloadDefinition.Age != nil {
+			age = *workloadDefinition.WorkloadDefinition.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*workloadDefinition.WorkloadDefinition.Name, "\t",
-			*workloadDefinition.WorkloadDefinition.Age,
+			age,
 		)
 	}
 	writer.Flush()
@@ -60,13 +77,31 @@ func outputGetv0WorkloadInstancesCmd(
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
 	fmt.Fprintln(writer, "NAME\t WORKLOAD DEFINITION\t KUBERNETES RUNTIME INSTANCE\t STATUS\t AGE")
 	for _, workloadInstance := range *workloadInstances {
+		workloadDefinitionName := ""
+		if workloadInstance.WorkloadInstance.WorkloadDefinition != nil &&
+			workloadInstance.WorkloadInstance.WorkloadDefinition.Name != nil {
+			workloadDefinitionName = *workloadInstance.WorkloadInstance.WorkloadDefinition.Name
+		}
+		kubernetesRuntimeInstanceName := ""
+		if workloadInstance.WorkloadInstance.KubernetesRuntimeInstance != nil &&
+			workloadInstance.WorkloadInstance.KubernetesRuntimeInstance.Name != nil {
+			kubernetesRuntimeInstanceName = *workloadInstance.WorkloadInstance.KubernetesRuntimeInstance.Name
+		}
+		status := ""
+		if workloadInstance.WorkloadInstance.Status != nil {
+			status = *workloadInstance.WorkloadInstance.Status
+		}
+		age := ""
+		if workloadInstance.WorkloadInstance.Age != nil {
+			age = *workloadInstance.WorkloadInstance.Age
+		}
 		fmt.Fprintln(
 			writer,
 			*workloadInstance.WorkloadInstance.Name, "\t",
-			*workloadInstance.WorkloadInstance.WorkloadDefinition.Name, "\t",
-			*workloadInstance.WorkloadInstance.KubernetesRuntimeInstance.Name, "\t",
-			*workloadInstance.WorkloadInstance.Status, "\t",
-			*workloadInstance.WorkloadInstance.Age,
+			workloadDefinitionName, "\t",
+			kubernetesRuntimeInstanceName, "\t",
+			status, "\t",
+			age,
 		)
 	}
 	writer.Flush()

--- a/cmd/tptctl/cmd/workload_get_output.go
+++ b/cmd/tptctl/cmd/workload_get_output.go
@@ -16,11 +16,10 @@ func outputGetv0WorkloadsCmd(
 	workloads *[]config_v0.WorkloadConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t WORKLOAD DEFINITION\t WORKLOAD INSTANCE\t KUBERNETES RUNTIME INSTANCE\t STATUS\t AGE")
+	fmt.Fprintln(writer, "NAME\t WORKLOAD DEFINITION\t WORKLOAD INSTANCE\t KUBERNETES RUNTIME INSTANCE\t STATUS\t AGE")
 	for _, workload := range *workloads {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*workload.Workload.Name, "\t",
 			*workload.Workload.Name, "\t",
 			*workload.Workload.Name, "\t",
@@ -40,11 +39,10 @@ func outputGetv0WorkloadDefinitionsCmd(
 	workloadDefinitions *[]config_v0.WorkloadDefinitionConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t AGE")
+	fmt.Fprintln(writer, "NAME\t AGE")
 	for _, workloadDefinition := range *workloadDefinitions {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*workloadDefinition.WorkloadDefinition.Name, "\t",
 			*workloadDefinition.WorkloadDefinition.Age,
 		)
@@ -60,11 +58,10 @@ func outputGetv0WorkloadInstancesCmd(
 	workloadInstances *[]config_v0.WorkloadInstanceConfig,
 ) error {
 	writer := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
-	fmt.Fprintln(writer, "VERSION\t NAME\t WORKLOAD DEFINITION\t KUBERNETES RUNTIME INSTANCE\t STATUS\t AGE")
+	fmt.Fprintln(writer, "NAME\t WORKLOAD DEFINITION\t KUBERNETES RUNTIME INSTANCE\t STATUS\t AGE")
 	for _, workloadInstance := range *workloadInstances {
 		fmt.Fprintln(
 			writer,
-			"v0", "\t",
 			*workloadInstance.WorkloadInstance.Name, "\t",
 			*workloadInstance.WorkloadInstance.WorkloadDefinition.Name, "\t",
 			*workloadInstance.WorkloadInstance.KubernetesRuntimeInstance.Name, "\t",

--- a/pkg/config/v0/aws_eks_kubernetes_runtime.go
+++ b/pkg/config/v0/aws_eks_kubernetes_runtime.go
@@ -222,7 +222,7 @@ func (a *AwsEksKubernetesRuntimeConfig) GetOperations(
 		Get: func() error {
 			awsEksKubernetesRuntimeInstance, err := awsEksKubernetesRuntimeInstanceConfig.Get(apiClient, apiEndpoint)
 			if err != nil {
-				return fmt.Errorf("failed to get aws eks kubernetes runtime instance with name %s: %w", *a.AwsEksKubernetesRuntime.Name, err)
+				return fmt.Errorf("failed to get aws eks kubernetes runtime instances: %w", err)
 			}
 			operatedAwsEksKubernetesRuntimeInstances = append(operatedAwsEksKubernetesRuntimeInstances, *awsEksKubernetesRuntimeInstance...)
 			return nil

--- a/pkg/config/v0/control_plane.go
+++ b/pkg/config/v0/control_plane.go
@@ -219,7 +219,7 @@ func (c *ControlPlaneConfig) GetOperations(
 		Get: func() error {
 			controlPlaneInstance, err := controlPlaneInstanceConfig.Get(apiClient, apiEndpoint)
 			if err != nil {
-				return fmt.Errorf("failed to get control plane instance with name %s: %w", *c.ControlPlane.Name, err)
+				return fmt.Errorf("failed to get control plane instances: %w", err)
 			}
 			operatedControlPlaneInstances = append(operatedControlPlaneInstances, *controlPlaneInstance...)
 			return nil

--- a/pkg/config/v0/domain_name.go
+++ b/pkg/config/v0/domain_name.go
@@ -217,7 +217,7 @@ func (d *DomainNameConfig) GetOperations(
 		Get: func() error {
 			domainNameInstance, err := domainNameInstanceConfig.Get(apiClient, apiEndpoint)
 			if err != nil {
-				return fmt.Errorf("failed to get domain name instance with name %s: %w", *d.DomainName.Name, err)
+				return fmt.Errorf("failed to get domain name instances: %w", err)
 			}
 			operatedDomainNameInstances = append(operatedDomainNameInstances, *domainNameInstance...)
 			return nil

--- a/pkg/config/v0/gateway.go
+++ b/pkg/config/v0/gateway.go
@@ -221,7 +221,7 @@ func (g *GatewayConfig) GetOperations(
 		Get: func() error {
 			gatewayInstance, err := gatewayInstanceConfig.Get(apiClient, apiEndpoint)
 			if err != nil {
-				return fmt.Errorf("failed to get gateway instance with name %s: %w", *g.Gateway.Name, err)
+				return fmt.Errorf("failed to get gateway instances: %w", err)
 			}
 			operatedGatewayInstances = append(operatedGatewayInstances, *gatewayInstance...)
 			return nil

--- a/pkg/config/v0/helm_workload.go
+++ b/pkg/config/v0/helm_workload.go
@@ -233,7 +233,7 @@ func (h *HelmWorkloadConfig) GetOperations(
 		Get: func() error {
 			helmWorkloadDefinition, err := helmWorkloadDefinitionConfig.Get(apiClient, apiEndpoint)
 			if err != nil {
-				return fmt.Errorf("failed to get helm workload definition with name %s: %w", *helmWorkloadValues.Name, err)
+				return fmt.Errorf("failed to get helm workload definitions: %w", err)
 			}
 			operatedHelmWorkloadDefinitions = append(operatedHelmWorkloadDefinitions, *helmWorkloadDefinition...)
 			return nil

--- a/pkg/config/v0/kubernetes_runtime.go
+++ b/pkg/config/v0/kubernetes_runtime.go
@@ -225,7 +225,7 @@ func (k *KubernetesRuntimeConfig) GetOperations(
 		Get: func() error {
 			kubernetesRuntimeInstance, err := kubernetesRuntimeInstanceConfig.Get(apiClient, apiEndpoint)
 			if err != nil {
-				return fmt.Errorf("failed to get kubernetes runtime instance with name %s: %w", *kubernetesRuntimeValues.Name, err)
+				return fmt.Errorf("failed to get kubernetes runtime instances: %w", err)
 			}
 			operatedKubernetesRuntimeInstances = append(operatedKubernetesRuntimeInstances, *kubernetesRuntimeInstance...)
 			return nil

--- a/pkg/config/v0/observability_stack.go
+++ b/pkg/config/v0/observability_stack.go
@@ -204,7 +204,7 @@ func (o *ObservabilityStackConfig) GetOperations(
 		Get: func() error {
 			observabilityStackDefinition, err := observabilityStackDefinitionConfig.Get(apiClient, apiEndpoint)
 			if err != nil {
-				return fmt.Errorf("failed to get observability stack definition with name %s: %w", *observabilityStackValues.Name, err)
+				return fmt.Errorf("failed to get observability stack definitions: %w", err)
 			}
 			operatedObservabilityStackDefinitions = append(operatedObservabilityStackDefinitions, *observabilityStackDefinition...)
 			return nil
@@ -258,7 +258,7 @@ func (o *ObservabilityStackConfig) GetOperations(
 		Get: func() error {
 			observabilityStackInstance, err := observabilityStackInstanceConfig.Get(apiClient, apiEndpoint)
 			if err != nil {
-				return fmt.Errorf("failed to get observability stack instance with name %s: %w", *observabilityStackValues.Name, err)
+				return fmt.Errorf("failed to get observability stack instances: %w", err)
 			}
 			operatedObservabilityStackInstances = append(operatedObservabilityStackInstances, *observabilityStackInstance...)
 			return nil

--- a/pkg/config/v0/oci_oke_kubernetes_runtime.go
+++ b/pkg/config/v0/oci_oke_kubernetes_runtime.go
@@ -216,7 +216,7 @@ func (o *OciOkeKubernetesRuntimeConfig) GetOperations(
 		Get: func() error {
 			ociOkeKubernetesRuntimeInstance, err := ociOkeKubernetesRuntimeInstanceConfig.Get(apiClient, apiEndpoint)
 			if err != nil {
-				return fmt.Errorf("failed to get oci oke kubernetes runtime instance with name %s: %w", *ociOkeKubernetesRuntimeValues.Name, err)
+				return fmt.Errorf("failed to get oci oke kubernetes runtime instances: %w", err)
 			}
 			operatedOciOkeKubernetesRuntimeInstances = append(operatedOciOkeKubernetesRuntimeInstances, *ociOkeKubernetesRuntimeInstance...)
 			return nil

--- a/pkg/config/v0/secret.go
+++ b/pkg/config/v0/secret.go
@@ -221,7 +221,7 @@ func (s *SecretConfig) GetOperations(
 		Get: func() error {
 			secretInstance, err := secretInstanceConfig.Get(apiClient, apiEndpoint)
 			if err != nil {
-				return fmt.Errorf("failed to get secret instance with name %s: %w", *secretValues.Name, err)
+				return fmt.Errorf("failed to get secret instances: %w", err)
 			}
 			operatedSecretInstances = append(operatedSecretInstances, *secretInstance...)
 			return nil

--- a/pkg/config/v0/workload.go
+++ b/pkg/config/v0/workload.go
@@ -218,7 +218,7 @@ func (w *WorkloadConfig) GetOperations(
 		Get: func() error {
 			workloadInstance, err := workloadInstanceConfig.Get(apiClient, apiEndpoint)
 			if err != nil {
-				return fmt.Errorf("failed to get workload instance/s: %w", err)
+				return fmt.Errorf("failed to get workload instances: %w", err)
 			}
 			operatedWorkloadInstances = append(operatedWorkloadInstances, *workloadInstance...)
 			return nil

--- a/pkg/sdk/v0/gen/cmd/cli/command.go
+++ b/pkg/sdk/v0/gen/cmd/cli/command.go
@@ -1668,12 +1668,11 @@ func GenCliCommands(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 							apiObj.Version,
 							strcase.ToSnake(rootObj),
 						),
-						Qual("fmt", "Fprintln").Call(Id("writer"), Lit("VERSION\t NAME\t AGE")),
+						Qual("fmt", "Fprintln").Call(Id("writer"), Lit("NAME\t AGE")),
 						For(
 							List(Id("_"), Id(rootObjectVar)).Op(":=").Range().Op("*").Id(pluralize.Pluralize(rootObjectVar, 2, false)).Block(
 								Qual("fmt", "Fprintln").Call(
 									Line().Id("writer"),
-									Line().Lit(apiObj.Version).Op(",").Lit("\t"),
 									Line().Op("*").Id(rootObjectVar).Dot(rootObj).Dot("Name").Op(",").Lit("\t"),
 									Line().Op("*").Id(rootObjectVar).Dot(rootObj).Dot("Age").Op(",").Line(),
 								),
@@ -1720,14 +1719,13 @@ func GenCliCommands(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 						apiObj.Version,
 						strcase.ToSnake(apiObj.TypeName),
 					),
-					Qual("fmt", "Fprintln").Call(Id("writer"), Lit("VERSION\t NAME\t AGE")),
+					Qual("fmt", "Fprintln").Call(Id("writer"), Lit("NAME\t AGE")),
 					For(List(
 						Id("_"),
 						Id(objectVar),
 					).Op(":=").Range().Op("*").Id(pluralize.Pluralize(objectVar, 2, false))).Block(
 						Qual("fmt", "Fprintln").Call(
 							Line().Id("writer"),
-							Line().Lit(apiObj.Version).Op(",").Lit("\t"),
 							Line().Op("*").Id(objectVar).Dot(apiObj.TypeName).Dot("Name").Op(",").Lit("\t"),
 							Line().Op("*").Id(objectVar).Dot(apiObj.TypeName).Dot("Age").Op(",").Line(),
 						),


### PR DESCRIPTION
The version column was intended to inform the user which version of an API object was being displayed.  It was an attempt to future-proof for when multiple versions exist.  However, it was just confusing.  We will tackle how to distinguish different API object versions when there are more versions to manage.