### PR TITLE
chore: remove redundant method on ThreeportConfig

### DIFF
--- a/cmd/tptctl/cmd/upgrade_control_plane.go
+++ b/cmd/tptctl/cmd/upgrade_control_plane.go
@@ -35,7 +35,7 @@ var UpgradeControlPlaneCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		apiClient, config, apiEndpoint, requestedControlPlane := GetClientContext(cmd)
 
-		encyptionKey, err := config.GetEncryptionKey(requestedControlPlane)
+		encyptionKey, err := config.GetThreeportEncryptionKey(requestedControlPlane)
 		if err != nil {
 			cli.Error("failed to retrieve encryption key for control plane:", err)
 			os.Exit(1)

--- a/pkg/cli/v0/config.go
+++ b/pkg/cli/v0/config.go
@@ -133,7 +133,7 @@ func (cfg *ThreeportConfig) GetThreeportAPIEndpoint(requestedControlPlane string
 func (cfg *ThreeportConfig) GetThreeportAuthEnabled(requestedControlPlane string) (bool, error) {
 	controlPlane, err := cfg.GetControlPlaneConfig(requestedControlPlane)
 	if err != nil {
-		return false, errors.New("current control plane not found when retrieving threeport API endpoint")
+		return false, errors.New("current control plane not found when determining if threeport auth is enabled")
 	}
 
 	return controlPlane.AuthEnabled, nil
@@ -144,7 +144,7 @@ func (cfg *ThreeportConfig) GetThreeportAuthEnabled(requestedControlPlane string
 func (cfg *ThreeportConfig) GetThreeportEncryptionKey(requestedControlPlane string) (string, error) {
 	controlPlane, err := cfg.GetControlPlaneConfig(requestedControlPlane)
 	if err != nil {
-		return "", errors.New("current control plane not found when retrieving threeport API endpoint")
+		return "", errors.New("current control plane not found when retrieving threeport encryption key")
 	}
 
 	return controlPlane.EncryptionKey, nil
@@ -168,16 +168,6 @@ func (cfg *ThreeportConfig) CheckThreeportGenesisControlPlane(requestedControlPl
 		return false, errors.New("current control plane not found when checking for genesis info")
 	}
 	return controlPlane.Genesis, nil
-}
-
-// GetEncryptionKey returns the encryption key from the threeport
-// config.
-func (cfg *ThreeportConfig) GetEncryptionKey(requestedControlPlane string) (string, error) {
-	controlPlane, err := cfg.GetControlPlaneConfig(requestedControlPlane)
-	if err != nil {
-		return "", errors.New("current instance not found when retrieving encryption key")
-	}
-	return controlPlane.EncryptionKey, nil
 }
 
 // GetThreeportCertificatesForControlPlane returns the CA certificate, client

--- a/test/integration/workload_test.go
+++ b/test/integration/workload_test.go
@@ -345,7 +345,7 @@ func TestWorkloadIntegration(t *testing.T) {
 		assert.Nil(err, "should have no error getting kubernetes runtime instance")
 		assert.NotNil(kubernetesRuntimeInstance, "should have a kubernetes runtime instance returned")
 
-		encryptionKey, err := threeportConfig.GetEncryptionKey(threeportConfig.CurrentControlPlane)
+		encryptionKey, err := threeportConfig.GetThreeportEncryptionKey(threeportConfig.CurrentControlPlane)
 		require.Nil(t, err, "should have no error getting encryption key")
 
 		// create a client to connect to kube API


### PR DESCRIPTION
There were two methods with identical functionality on the ThreeportConfig object:

* GetEncryptionKey
* GetThreeportEncryptionKey

This commit removes the first method and retains the second.