### PR TITLE
fix: emit working codegen for tptctl config path feature

### DIFF
--- a/pkg/sdk/v0/gen/cmd/cli/command.go
+++ b/pkg/sdk/v0/gen/cmd/cli/command.go
@@ -392,7 +392,7 @@ func GenCliCommands(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 					// path variable must be set on the config object
 					setConfigPath := &Statement{}
 					if apiObj.TptctlConfigPath || apiObj.DefinedInstanceTptctlConfigPath {
-						setConfigPath.Id(rootObjectVar).Dot(configPathField).Op("=").Op("&").Id(configPathVar)
+						setConfigPath.Id(rootObjectConfigVar).Dot(rootObj).Dot(configPathField).Op("=").Op("&").Id(configPathVar)
 					}
 
 					commandCode.Comment(fmt.Sprintf(
@@ -597,7 +597,7 @@ func GenCliCommands(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 					// path variable must be set on the config object
 					setConfigPath = &Statement{}
 					if apiObj.TptctlConfigPath {
-						setConfigPath.Id(rootObjectVar).Dot(configPathField).Op("=").Op("&").Id(configPathVar)
+						setConfigPath.Id(rootObjectConfigVar).Dot(rootObj).Dot(configPathField).Op("=").Op("&").Id(configPathVar)
 					}
 
 					commandCode.Comment(fmt.Sprintf(
@@ -1078,7 +1078,7 @@ func GenCliCommands(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 				// path variable must be set on the config object
 				setConfigPath := &Statement{}
 				if apiObj.TptctlConfigPath {
-					setConfigPath.Id(objectVar).Dot(configPathField).Op("=").Op("&").Id(configPathVar)
+					setConfigPath.Id(objectConfigVar).Dot(apiObj.TypeName).Dot(configPathField).Op("=").Op("&").Id(configPathVar)
 				}
 
 				commandCode.Comment(fmt.Sprintf(
@@ -1437,7 +1437,7 @@ func GenCliCommands(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 				// path variable must be set on the config object
 				setConfigPath = &Statement{}
 				if apiObj.TptctlConfigPath {
-					setConfigPath.Id(objectVar).Dot(configPathField).Op("=").Op("&").Id(configPathVar)
+					setConfigPath.Id(objectConfigVar).Dot(apiObj.TypeName).Dot(configPathField).Op("=").Op("&").Id(configPathVar)
 				}
 
 				commandCode.Comment(fmt.Sprintf(

--- a/pkg/sdk/v0/gen/pkg/config/config.go
+++ b/pkg/sdk/v0/gen/pkg/config/config.go
@@ -91,7 +91,7 @@ func GenConfig(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 						instObject,
 					)
 					f.Comment("together with a single operation.")
-					f.Type().Id(defInstValuesObjectName).Struct(
+					defInstFields := []Code{
 						Commentf(
 							"TODO: add fields needed for user to manage a %s and %s together",
 							defObject,
@@ -99,7 +99,12 @@ func GenConfig(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 						),
 						Id("Name").Op("*").String().Tag(map[string]string{"yaml": "Name,omitempty", "json": "Name,omitempty"}),
 						Id("Age").Op("*").String().Tag(map[string]string{"yaml": "Age,omitempty", "json": "Age,omitempty"}),
-					)
+					}
+					if apiObject.TptctlConfigPath || apiObject.DefinedInstanceTptctlConfigPath {
+						configPathField := fmt.Sprintf("%sConfigPath", strcase.ToCamel(objGroup.Name))
+						defInstFields = append(defInstFields, Id(configPathField).Op("*").String().Tag(map[string]string{"yaml": configPathField + ",omitempty", "json": configPathField + ",omitempty"}))
+					}
+					f.Type().Id(defInstValuesObjectName).Struct(defInstFields...)
 					f.Line()
 
 					// Get method
@@ -707,35 +712,41 @@ func GenConfig(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 						valuesObjectName,
 					)
 					f.Commentf("the %s API object.", apiObject.TypeName)
+					var valuesFields []Code
 					if apiObject.NameField {
 						if apiObject.DefinedInstanceInstance {
-							f.Type().Id(valuesObjectName).Struct(
+							valuesFields = []Code{
 								Comment(configFieldTodoComment),
 								Id("Name").Op("*").String().Tag(map[string]string{"yaml": "Name,omitempty", "json": "Name,omitempty"}),
 								Id(defObject).Op("*").Id(defValuesObject).Tag(map[string]string{"yaml": defObject + ",omitempty", "json": defObject + ",omitempty"}),
 								Id("Age").Op("*").String().Tag(map[string]string{"yaml": "Age,omitempty", "json": "Age,omitempty"}),
-							)
+							}
 						} else {
-							f.Type().Id(valuesObjectName).Struct(
+							valuesFields = []Code{
 								Comment(configFieldTodoComment),
 								Id("Name").Op("*").String().Tag(map[string]string{"yaml": "Name,omitempty", "json": "Name,omitempty"}),
 								Id("Age").Op("*").String().Tag(map[string]string{"yaml": "Age,omitempty", "json": "Age,omitempty"}),
-							)
+							}
 						}
 					} else {
 						if apiObject.DefinedInstanceInstance {
-							f.Type().Id(valuesObjectName).Struct(
+							valuesFields = []Code{
 								Comment(configFieldTodoComment),
 								Id(defObject).Op("*").Id(defValuesObject).Tag(map[string]string{"yaml": defObject + ",omitempty", "json": defObject + ",omitempty"}),
 								Id("Age").Op("*").String().Tag(map[string]string{"yaml": "Age,omitempty", "json": "Age,omitempty"}),
-							)
+							}
 						} else {
-							f.Type().Id(valuesObjectName).Struct(
+							valuesFields = []Code{
 								Comment(configFieldTodoComment),
 								Id("Age").Op("*").String().Tag(map[string]string{"yaml": "Age,omitempty", "json": "Age,omitempty"}),
-							)
+							}
 						}
 					}
+					if apiObject.TptctlConfigPath {
+						configPathField := fmt.Sprintf("%sConfigPath", strcase.ToCamel(objGroup.Name))
+						valuesFields = append(valuesFields, Id(configPathField).Op("*").String().Tag(map[string]string{"yaml": configPathField + ",omitempty", "json": configPathField + ",omitempty"}))
+					}
+					f.Type().Id(valuesObjectName).Struct(valuesFields...)
 					f.Line()
 
 					// Generate Get method


### PR DESCRIPTION
Fixes two codegen bugs that made `Tptctl.ConfigPath: true` in `sdk-config.yaml` produce non-compiling output.

In `pkg/sdk/v0/gen/cmd/cli/command.go` the generator referenced an identifier that was never declared. It now walks through the `*Config` wrapper in scope (for example `exampleConfig.Example.ExampleConfigPath` instead of `example.ExampleConfigPath`).

In `pkg/sdk/v0/gen/pkg/config/config.go` the emitted `*Values` struct never included the `<Group>ConfigPath *string` field that those assignments targeted. It now conditionally appends that field at both emission sites when the flag is set.