### PR TITLE
feat: drive release image arch from sdk config

### DIFF
--- a/pkg/sdk/v0/config.go
+++ b/pkg/sdk/v0/config.go
@@ -28,6 +28,11 @@ type SdkConfig struct {
 	// A repository for each module will be created in this namespace.
 	ImageNamespace string `yaml:"ImageNamespace"`
 
+	// The CPU architecture used for release image builds, e.g. `amd64` or
+	// `arm64`. Defaults to `amd64` when unset. Dev image builds always use
+	// the host architecture.
+	ReleaseArch string `yaml:"ReleaseArch"`
+
 	// Details to be displayed with the API swagger docs that are served by the
 	// API server.
 	ApiDocs ApiDocs `yaml:"ApiDocs"`

--- a/pkg/sdk/v0/config.go
+++ b/pkg/sdk/v0/config.go
@@ -189,6 +189,15 @@ func ValidateSdkConfig(sdkConfig *SdkConfig) error {
 		return fmt.Errorf("ApiNamespace is a required field")
 	}
 
+	switch sdkConfig.ReleaseArch {
+	case "", "amd64", "arm64":
+	default:
+		return fmt.Errorf(
+			"invalid ReleaseArch %q: supported values are amd64, arm64 (default: amd64)",
+			sdkConfig.ReleaseArch,
+		)
+	}
+
 	// check to make sure that defined instance objects have matching values for
 	// the `DefinedInstance` field.  If they don't the API object definitions
 	// will be incompatible.

--- a/pkg/sdk/v0/gen/root/magefile.go
+++ b/pkg/sdk/v0/gen/root/magefile.go
@@ -71,7 +71,11 @@ func GenMagefile(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 	buildAgentReleaseImageFuncName := "AgentImageRelease"
 	buildReleaseImageFuncNames := []string{buildApiReleaseImageFuncName, buildDbMigratorReleaseImageFuncName}
 
-	f.Const().Id("releaseArch").Op("=").Lit("amd64")
+	releaseArch := sdkConfig.ReleaseArch
+	if releaseArch == "" {
+		releaseArch = "amd64"
+	}
+	f.Const().Id("releaseArch").Op("=").Lit(releaseArch)
 	f.Line()
 
 	namespaces := []string{"Build", "Test", "Install", "Dev"}


### PR DESCRIPTION
Adds a `ReleaseArch` field to `sdk-config.yaml` so downstream modules can declare their release image architecture. The generated release mage target reads this field instead of hardcoding `amd64`, and validates the value against a whitelist of supported architectures.