### PR TITLE
fix: assert pointer type in before update hooks

### DIFF
--- a/pkg/api/v0/aws_validate.go
+++ b/pkg/api/v0/aws_validate.go
@@ -106,8 +106,8 @@ func (a *AwsProvider) BeforeUpdate(tx *gorm.DB) error {
 	if encryptionKey == "" {
 		return errors.New("environment variable ENCRYPTION_KEY is not set")
 	}
-	updatedObj := tx.Statement.Dest.(AwsProvider)
-	objVal := reflect.ValueOf(&updatedObj).Elem()
+	updatedObj := tx.Statement.Dest.(*AwsProvider)
+	objVal := reflect.ValueOf(updatedObj).Elem()
 	objType := objVal.Type()
 	for i := 0; i < objType.NumField(); i++ {
 		field := objType.Field(i)

--- a/pkg/api/v0/kubernetes_runtime_validate.go
+++ b/pkg/api/v0/kubernetes_runtime_validate.go
@@ -149,8 +149,8 @@ func (k *KubernetesRuntimeInstance) BeforeUpdate(tx *gorm.DB) error {
 	if encryptionKey == "" {
 		return errors.New("environment variable ENCRYPTION_KEY is not set")
 	}
-	updatedObj := tx.Statement.Dest.(KubernetesRuntimeInstance)
-	objVal := reflect.ValueOf(&updatedObj).Elem()
+	updatedObj := tx.Statement.Dest.(*KubernetesRuntimeInstance)
+	objVal := reflect.ValueOf(updatedObj).Elem()
 	objType := objVal.Type()
 	for i := 0; i < objType.NumField(); i++ {
 		field := objType.Field(i)

--- a/pkg/api/v0/oci_validate.go
+++ b/pkg/api/v0/oci_validate.go
@@ -65,8 +65,8 @@ func (o *OciProvider) BeforeUpdate(tx *gorm.DB) error {
 		return errors.New("environment variable ENCRYPTION_KEY is not set")
 	}
 
-	updatedObj := tx.Statement.Dest.(OciProvider)
-	objVal := reflect.ValueOf(&updatedObj).Elem()
+	updatedObj := tx.Statement.Dest.(*OciProvider)
+	objVal := reflect.ValueOf(updatedObj).Elem()
 	objType := objVal.Type()
 	for i := 0; i < objType.NumField(); i++ {
 		field := objType.Field(i)


### PR DESCRIPTION
Gorm's `BeforeUpdate()` callback receives the record via `tx.Statement.Dest` as a pointer (`*T`). The current hooks on `AwsAccount`, `KubernetesRuntimeInstance`, and `OciProvider` assert to a value type, which panics whenever an update actually runs. Change each hook to assert `*T` and operate on the pointer directly:
```go
    updatedObj := tx.Statement.Dest.(*T)
    objVal := reflect.ValueOf(updatedObj).Elem()
```