### PR TITLE
fix: sign OKE token requests with TenancyOCID, not CompartmentOCID

### DIFF
--- a/pkg/kube/v0/cluster.go
+++ b/pkg/kube/v0/cluster.go
@@ -388,7 +388,7 @@ func refreshOKEConnection(
 	if token, tokenExpirationTime, err = util.GenerateOkeToken(
 		*okeRuntimeInstance.ClusterOCID,
 		common.NewRawConfigurationProvider(
-			*ociProvider.CompartmentOCID,
+			*ociProvider.TenancyOCID,
 			*ociProvider.UserOCID,
 			*ociProvider.DefaultRegion,
 			*ociProvider.KeyFingerprint,


### PR DESCRIPTION
OCI API request signing requires the tenancy OCID, not the compartment OCID, as the "tenancy" component of the key identifier. Using the compartment OCID works only when the compartment happens to be the root compartment (which equals the tenancy), and silently fails signature verification otherwise. Fixes authentication failures when OKE clusters live in a non-root compartment.