### PR TITLE
fix: tptdev push only the specified tag

### DIFF
--- a/pkg/threeport-installer/v0/tptdev/images.go
+++ b/pkg/threeport-installer/v0/tptdev/images.go
@@ -211,7 +211,7 @@ func PushDockerImage(tag string) error {
 		isDockerConfigPresent = false
 	}
 
-	imagePushOptions := image.PushOptions{All: true}
+	imagePushOptions := image.PushOptions{}
 
 	dockerUsername := os.Getenv("DOCKER_USERNAME")
 	dockerPassword := os.Getenv("DOCKER_PASSWORD")


### PR DESCRIPTION
Docker's `image.PushOptions{All: true}` pushes every tag attached to the image manifest. Drop `All: true` so the push only sends the tag `tptdev` was invoked with.