### PR TITLE
fix: capture created module object id in module registration

### DIFF
--- a/pkg/sdk/v0/gen/pkg/api-server/module.go
+++ b/pkg/sdk/v0/gen/pkg/api-server/module.go
@@ -882,7 +882,7 @@ func GenModuleRegistration(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 								).Call(Lit(apiObj.Description)),
 								Id("ModuleApiID"): Id("existingModApi").Dot("ID"),
 							}),
-							List(Id("_"), Id("err")).Op(":=").Qual(
+							List(Id("objectResult"), Id("err")).Op(":=").Qual(
 								"github.com/threeport/threeport/pkg/client/v0", "CreateModuleObject",
 							).Call(
 								Id("tpApiClient"),
@@ -895,6 +895,7 @@ func GenModuleRegistration(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 									Id("err"),
 								)),
 							),
+							Id(objectVar).Op("=").Op("*").Id("objectResult"),
 						).Else().If(Len(Op("*").Id(objectSliceVar)).Op("==").Lit(1)).Block(
 							Id(objectVar).Op("=").Parens(Op("*").Id(objectSliceVar)).Index(Lit(0)),
 						).Else().Block(
@@ -1020,7 +1021,7 @@ func GenModuleRegistration(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 							).Call(Lit(apiObj.Description)),
 							Id("ModuleApiID"): Id("existingModApi").Dot("ID"),
 						}),
-						List(Id("_"), Id("err")).Op(":=").Qual(
+						List(Id("objectResult"), Id("err")).Op(":=").Qual(
 							"github.com/threeport/threeport/pkg/client/v0",
 							"CreateModuleObject",
 						).Call(
@@ -1034,6 +1035,7 @@ func GenModuleRegistration(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 								Id("err"),
 							)),
 						),
+						Id(objectVar).Op("=").Op("*").Id("objectResult"),
 					).Else().If(Len(Op("*").Id(objectSliceVar)).Op("==").Lit(1)).Block(
 						Id(objectVar).Op("=").Parens(Op("*").Id(objectSliceVar)).Index(Lit(0)),
 					).Else().Block(


### PR DESCRIPTION
CreateModuleObject() returns the persisted object with its DB-assigned ID. The
generator was discarding it via `_`, leaving the local variable at the zero
value. Downstream code in the same generated function reads that variable's ID
to write foreign-key references for related rows, so module registration
silently bound dependents to ID 0.

This captures the return value and assigns it back into the local so the rest
of the generated flow sees the populated object.