### PR TITLE
fix: align method doc comments with renamed 'get' prefix

### DIFF
--- a/pkg/api/v0/actuator_gen.go
+++ b/pkg/api/v0/actuator_gen.go
@@ -62,12 +62,12 @@ func (p *Profile) GetId() uint {
 	return *p.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (p *Profile) GetType() string {
 	return "Profile"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (p *Profile) GetVersion() string {
 	return "v0"
 }
@@ -116,12 +116,12 @@ func (t *Tier) GetId() uint {
 	return *t.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (t *Tier) GetType() string {
 	return "Tier"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (t *Tier) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/attached_object_gen.go
+++ b/pkg/api/v0/attached_object_gen.go
@@ -59,12 +59,12 @@ func (aor *AttachedObjectReference) GetId() uint {
 	return *aor.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (aor *AttachedObjectReference) GetType() string {
 	return "AttachedObjectReference"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (aor *AttachedObjectReference) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/aws_gen.go
+++ b/pkg/api/v0/aws_gen.go
@@ -66,12 +66,12 @@ func (aekrd *AwsEksKubernetesRuntimeDefinition) GetId() uint {
 	return *aekrd.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (aekrd *AwsEksKubernetesRuntimeDefinition) GetType() string {
 	return "AwsEksKubernetesRuntimeDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (aekrd *AwsEksKubernetesRuntimeDefinition) GetVersion() string {
 	return "v0"
 }
@@ -120,12 +120,12 @@ func (aekri *AwsEksKubernetesRuntimeInstance) GetId() uint {
 	return *aekri.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (aekri *AwsEksKubernetesRuntimeInstance) GetType() string {
 	return "AwsEksKubernetesRuntimeInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (aekri *AwsEksKubernetesRuntimeInstance) GetVersion() string {
 	return "v0"
 }
@@ -180,12 +180,12 @@ func (ap *AwsProvider) GetId() uint {
 	return *ap.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (ap *AwsProvider) GetType() string {
 	return "AwsProvider"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (ap *AwsProvider) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/control_plane_gen.go
+++ b/pkg/api/v0/control_plane_gen.go
@@ -63,12 +63,12 @@ func (cpd *ControlPlaneDefinition) GetId() uint {
 	return *cpd.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (cpd *ControlPlaneDefinition) GetType() string {
 	return "ControlPlaneDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (cpd *ControlPlaneDefinition) GetVersion() string {
 	return "v0"
 }
@@ -123,12 +123,12 @@ func (cpi *ControlPlaneInstance) GetId() uint {
 	return *cpi.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (cpi *ControlPlaneInstance) GetType() string {
 	return "ControlPlaneInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (cpi *ControlPlaneInstance) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/events_gen.go
+++ b/pkg/api/v0/events_gen.go
@@ -59,12 +59,12 @@ func (e *Event) GetId() uint {
 	return *e.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (e *Event) GetType() string {
 	return "Event"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (e *Event) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/gateway_gen.go
+++ b/pkg/api/v0/gateway_gen.go
@@ -75,12 +75,12 @@ func (dnd *DomainNameDefinition) GetId() uint {
 	return *dnd.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (dnd *DomainNameDefinition) GetType() string {
 	return "DomainNameDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (dnd *DomainNameDefinition) GetVersion() string {
 	return "v0"
 }
@@ -129,12 +129,12 @@ func (dni *DomainNameInstance) GetId() uint {
 	return *dni.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (dni *DomainNameInstance) GetType() string {
 	return "DomainNameInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (dni *DomainNameInstance) GetVersion() string {
 	return "v0"
 }
@@ -189,12 +189,12 @@ func (gd *GatewayDefinition) GetId() uint {
 	return *gd.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (gd *GatewayDefinition) GetType() string {
 	return "GatewayDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (gd *GatewayDefinition) GetVersion() string {
 	return "v0"
 }
@@ -249,12 +249,12 @@ func (ghp *GatewayHttpPort) GetId() uint {
 	return *ghp.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (ghp *GatewayHttpPort) GetType() string {
 	return "GatewayHttpPort"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (ghp *GatewayHttpPort) GetVersion() string {
 	return "v0"
 }
@@ -303,12 +303,12 @@ func (gi *GatewayInstance) GetId() uint {
 	return *gi.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (gi *GatewayInstance) GetType() string {
 	return "GatewayInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (gi *GatewayInstance) GetVersion() string {
 	return "v0"
 }
@@ -363,12 +363,12 @@ func (gtp *GatewayTcpPort) GetId() uint {
 	return *gtp.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (gtp *GatewayTcpPort) GetType() string {
 	return "GatewayTcpPort"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (gtp *GatewayTcpPort) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/gcp_gen.go
+++ b/pkg/api/v0/gcp_gen.go
@@ -66,12 +66,12 @@ func (ggkrd *GcpGkeKubernetesRuntimeDefinition) GetId() uint {
 	return *ggkrd.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (ggkrd *GcpGkeKubernetesRuntimeDefinition) GetType() string {
 	return "GcpGkeKubernetesRuntimeDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (ggkrd *GcpGkeKubernetesRuntimeDefinition) GetVersion() string {
 	return "v0"
 }
@@ -120,12 +120,12 @@ func (ggkri *GcpGkeKubernetesRuntimeInstance) GetId() uint {
 	return *ggkri.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (ggkri *GcpGkeKubernetesRuntimeInstance) GetType() string {
 	return "GcpGkeKubernetesRuntimeInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (ggkri *GcpGkeKubernetesRuntimeInstance) GetVersion() string {
 	return "v0"
 }
@@ -180,12 +180,12 @@ func (gp *GcpProvider) GetId() uint {
 	return *gp.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (gp *GcpProvider) GetType() string {
 	return "GcpProvider"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (gp *GcpProvider) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/helm_workload_gen.go
+++ b/pkg/api/v0/helm_workload_gen.go
@@ -63,12 +63,12 @@ func (hwd *HelmWorkloadDefinition) GetId() uint {
 	return *hwd.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (hwd *HelmWorkloadDefinition) GetType() string {
 	return "HelmWorkloadDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (hwd *HelmWorkloadDefinition) GetVersion() string {
 	return "v0"
 }
@@ -123,12 +123,12 @@ func (hwi *HelmWorkloadInstance) GetId() uint {
 	return *hwi.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (hwi *HelmWorkloadInstance) GetType() string {
 	return "HelmWorkloadInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (hwi *HelmWorkloadInstance) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/kubernetes_runtime_gen.go
+++ b/pkg/api/v0/kubernetes_runtime_gen.go
@@ -63,12 +63,12 @@ func (krd *KubernetesRuntimeDefinition) GetId() uint {
 	return *krd.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (krd *KubernetesRuntimeDefinition) GetType() string {
 	return "KubernetesRuntimeDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (krd *KubernetesRuntimeDefinition) GetVersion() string {
 	return "v0"
 }
@@ -123,12 +123,12 @@ func (kri *KubernetesRuntimeInstance) GetId() uint {
 	return *kri.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (kri *KubernetesRuntimeInstance) GetType() string {
 	return "KubernetesRuntimeInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (kri *KubernetesRuntimeInstance) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/log_gen.go
+++ b/pkg/api/v0/log_gen.go
@@ -65,12 +65,12 @@ func (lb *LogBackend) GetId() uint {
 	return *lb.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (lb *LogBackend) GetType() string {
 	return "LogBackend"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (lb *LogBackend) GetVersion() string {
 	return "v0"
 }
@@ -119,12 +119,12 @@ func (lsd *LogStorageDefinition) GetId() uint {
 	return *lsd.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (lsd *LogStorageDefinition) GetType() string {
 	return "LogStorageDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (lsd *LogStorageDefinition) GetVersion() string {
 	return "v0"
 }
@@ -173,12 +173,12 @@ func (lsi *LogStorageInstance) GetId() uint {
 	return *lsi.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (lsi *LogStorageInstance) GetType() string {
 	return "LogStorageInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (lsi *LogStorageInstance) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/module_gen.go
+++ b/pkg/api/v0/module_gen.go
@@ -68,12 +68,12 @@ func (ma *ModuleApi) GetId() uint {
 	return *ma.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (ma *ModuleApi) GetType() string {
 	return "ModuleApi"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (ma *ModuleApi) GetVersion() string {
 	return "v0"
 }
@@ -122,12 +122,12 @@ func (mar *ModuleApiRoute) GetId() uint {
 	return *mar.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (mar *ModuleApiRoute) GetType() string {
 	return "ModuleApiRoute"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (mar *ModuleApiRoute) GetVersion() string {
 	return "v0"
 }
@@ -176,12 +176,12 @@ func (mc *ModuleController) GetId() uint {
 	return *mc.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (mc *ModuleController) GetType() string {
 	return "ModuleController"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (mc *ModuleController) GetVersion() string {
 	return "v0"
 }
@@ -230,12 +230,12 @@ func (mo *ModuleObject) GetId() uint {
 	return *mo.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (mo *ModuleObject) GetType() string {
 	return "ModuleObject"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (mo *ModuleObject) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/observability_gen.go
+++ b/pkg/api/v0/observability_gen.go
@@ -81,12 +81,12 @@ func (ld *LoggingDefinition) GetId() uint {
 	return *ld.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (ld *LoggingDefinition) GetType() string {
 	return "LoggingDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (ld *LoggingDefinition) GetVersion() string {
 	return "v0"
 }
@@ -141,12 +141,12 @@ func (li *LoggingInstance) GetId() uint {
 	return *li.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (li *LoggingInstance) GetType() string {
 	return "LoggingInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (li *LoggingInstance) GetVersion() string {
 	return "v0"
 }
@@ -201,12 +201,12 @@ func (md *MetricsDefinition) GetId() uint {
 	return *md.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (md *MetricsDefinition) GetType() string {
 	return "MetricsDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (md *MetricsDefinition) GetVersion() string {
 	return "v0"
 }
@@ -261,12 +261,12 @@ func (mi *MetricsInstance) GetId() uint {
 	return *mi.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (mi *MetricsInstance) GetType() string {
 	return "MetricsInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (mi *MetricsInstance) GetVersion() string {
 	return "v0"
 }
@@ -321,12 +321,12 @@ func (odd *ObservabilityDashboardDefinition) GetId() uint {
 	return *odd.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (odd *ObservabilityDashboardDefinition) GetType() string {
 	return "ObservabilityDashboardDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (odd *ObservabilityDashboardDefinition) GetVersion() string {
 	return "v0"
 }
@@ -381,12 +381,12 @@ func (odi *ObservabilityDashboardInstance) GetId() uint {
 	return *odi.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (odi *ObservabilityDashboardInstance) GetType() string {
 	return "ObservabilityDashboardInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (odi *ObservabilityDashboardInstance) GetVersion() string {
 	return "v0"
 }
@@ -441,12 +441,12 @@ func (osd *ObservabilityStackDefinition) GetId() uint {
 	return *osd.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (osd *ObservabilityStackDefinition) GetType() string {
 	return "ObservabilityStackDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (osd *ObservabilityStackDefinition) GetVersion() string {
 	return "v0"
 }
@@ -501,12 +501,12 @@ func (osi *ObservabilityStackInstance) GetId() uint {
 	return *osi.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (osi *ObservabilityStackInstance) GetType() string {
 	return "ObservabilityStackInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (osi *ObservabilityStackInstance) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/oci_gen.go
+++ b/pkg/api/v0/oci_gen.go
@@ -66,12 +66,12 @@ func (ookrd *OciOkeKubernetesRuntimeDefinition) GetId() uint {
 	return *ookrd.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (ookrd *OciOkeKubernetesRuntimeDefinition) GetType() string {
 	return "OciOkeKubernetesRuntimeDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (ookrd *OciOkeKubernetesRuntimeDefinition) GetVersion() string {
 	return "v0"
 }
@@ -120,12 +120,12 @@ func (ookri *OciOkeKubernetesRuntimeInstance) GetId() uint {
 	return *ookri.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (ookri *OciOkeKubernetesRuntimeInstance) GetType() string {
 	return "OciOkeKubernetesRuntimeInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (ookri *OciOkeKubernetesRuntimeInstance) GetVersion() string {
 	return "v0"
 }
@@ -180,12 +180,12 @@ func (op *OciProvider) GetId() uint {
 	return *op.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (op *OciProvider) GetType() string {
 	return "OciProvider"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (op *OciProvider) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/secret_gen.go
+++ b/pkg/api/v0/secret_gen.go
@@ -63,12 +63,12 @@ func (sd *SecretDefinition) GetId() uint {
 	return *sd.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (sd *SecretDefinition) GetType() string {
 	return "SecretDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (sd *SecretDefinition) GetVersion() string {
 	return "v0"
 }
@@ -123,12 +123,12 @@ func (si *SecretInstance) GetId() uint {
 	return *si.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (si *SecretInstance) GetType() string {
 	return "SecretInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (si *SecretInstance) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/terraform_gen.go
+++ b/pkg/api/v0/terraform_gen.go
@@ -63,12 +63,12 @@ func (td *TerraformDefinition) GetId() uint {
 	return *td.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (td *TerraformDefinition) GetType() string {
 	return "TerraformDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (td *TerraformDefinition) GetVersion() string {
 	return "v0"
 }
@@ -123,12 +123,12 @@ func (ti *TerraformInstance) GetId() uint {
 	return *ti.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (ti *TerraformInstance) GetType() string {
 	return "TerraformInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (ti *TerraformInstance) GetVersion() string {
 	return "v0"
 }

--- a/pkg/api/v0/workload_gen.go
+++ b/pkg/api/v0/workload_gen.go
@@ -72,12 +72,12 @@ func (wd *WorkloadDefinition) GetId() uint {
 	return *wd.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (wd *WorkloadDefinition) GetType() string {
 	return "WorkloadDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (wd *WorkloadDefinition) GetVersion() string {
 	return "v0"
 }
@@ -132,12 +132,12 @@ func (we *WorkloadEvent) GetId() uint {
 	return *we.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (we *WorkloadEvent) GetType() string {
 	return "WorkloadEvent"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (we *WorkloadEvent) GetVersion() string {
 	return "v0"
 }
@@ -186,12 +186,12 @@ func (wi *WorkloadInstance) GetId() uint {
 	return *wi.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (wi *WorkloadInstance) GetType() string {
 	return "WorkloadInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (wi *WorkloadInstance) GetVersion() string {
 	return "v0"
 }
@@ -246,12 +246,12 @@ func (wrd *WorkloadResourceDefinition) GetId() uint {
 	return *wrd.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (wrd *WorkloadResourceDefinition) GetType() string {
 	return "WorkloadResourceDefinition"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (wrd *WorkloadResourceDefinition) GetVersion() string {
 	return "v0"
 }
@@ -300,12 +300,12 @@ func (wri *WorkloadResourceInstance) GetId() uint {
 	return *wri.ID
 }
 
-// Type returns the object type.
+// GetType returns the object type.
 func (wri *WorkloadResourceInstance) GetType() string {
 	return "WorkloadResourceInstance"
 }
 
-// Version returns the version of the API object.
+// GetVersion returns the version of the API object.
 func (wri *WorkloadResourceInstance) GetVersion() string {
 	return "v0"
 }

--- a/pkg/sdk/v0/gen/pkg/api/methods.go
+++ b/pkg/sdk/v0/gen/pkg/api/methods.go
@@ -170,15 +170,15 @@ func GenApiObjectMethods(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 				).Id("GetId").Params().Uint().Block(
 					Return(Op("*").Id(util.TypeAbbrev(apiObj.TypeName)).Dot("ID")),
 				)
-				// Type method
-				f.Comment("Type returns the object type.")
+				// GetType method
+				f.Comment("GetType returns the object type.")
 				f.Func().Params(
 					Id(util.TypeAbbrev(apiObj.TypeName)).Op("*").Id(apiObj.TypeName),
 				).Id("GetType").Params().String().Block(
 					Return(Lit(apiObj.TypeName)),
 				)
-				// Version method
-				f.Comment("Version returns the version of the API object.")
+				// GetVersion method
+				f.Comment("GetVersion returns the version of the API object.")
 				f.Func().Params(
 					Id(util.TypeAbbrev(apiObj.TypeName)).Op("*").Id(apiObj.TypeName),
 				).Id("GetVersion").Params().String().Block(


### PR DESCRIPTION
The current comments mismatch the function names — they're holdovers from when these methods were named `Type()` and `Version()` before the `Get` prefix was added. This is a comment-only fix.
