### PR TITLE
fix: reject null on required fields in payload check

### DIFF
--- a/pkg/api-server/lib/v0/context.go
+++ b/pkg/api-server/lib/v0/context.go
@@ -190,11 +190,10 @@ func checkPayloadObject(apiVer string, payloadObject map[string]interface{}, obj
 	optionalAssociationsFields = &ObjectTaggedFields[VersionObject{Version: apiVer, Object: string(objectType)}].OptionalAssociations
 	requiredFields = &ObjectTaggedFields[VersionObject{Version: apiVer, Object: string(objectType)}].Required
 
-	// reject explicit null on a required field. gorm.Updates(struct)
-	// silently drops nil pointer fields, so the BeforeUpdate relationship
-	// hook never sees the set->nil transition. catching it here enforces
-	// the required contract uniformly across create and update.
-	if nulledRequiredFields := nullValuedRequiredFields(payloadObject, *requiredFields, objectStruct); len(nulledRequiredFields) > 0 {
+	// reject explicit null on a required field; gorm.Updates drops nil
+	// pointer fields silently so the violation is invisible downstream.
+	nulledRequiredFields := nullValuedRequiredFields(payloadObject, *requiredFields, objectStruct)
+	if len(nulledRequiredFields) > 0 {
 		return 400, errors.New(ErrMsgRequiredFieldsCannotBeNull + " : " + strings.Join(nulledRequiredFields, ","))
 	}
 
@@ -238,24 +237,28 @@ func readBody(c echo.Context) []byte {
 	return bodyBytes
 }
 
-// nullValuedRequiredFields returns the Go field names of any required
-// fields that appear in the payload with a JSON null value. Payload
-// keys are matched directly against required field names, or via the
-// `json:` tag alias on the target struct.
-func nullValuedRequiredFields(payloadObject map[string]interface{}, requiredFields []string, objectStruct interface{}) []string {
+// nullValuedRequiredFields returns Go field names of required fields
+// present in the payload with a JSON null value.
+func nullValuedRequiredFields(
+	payloadObject map[string]interface{},
+	requiredFields []string,
+	objectStruct interface{},
+) []string {
 	var nulled []string
 	for k, v := range payloadObject {
+		// only null values can violate the required contract
 		if v != nil {
 			continue
 		}
+		// payload key matches a required Go field name directly
 		if util.StringSliceContains(requiredFields, k, false) {
 			nulled = append(nulled, k)
 			continue
 		}
-		if alias := getFieldNameByJsonTag(k, "json", objectStruct); alias != "" {
-			if util.StringSliceContains(requiredFields, alias, false) {
-				nulled = append(nulled, alias)
-			}
+		// payload key may be a json tag alias; resolve to the Go field name
+		alias := getFieldNameByJsonTag(k, "json", objectStruct)
+		if alias != "" && util.StringSliceContains(requiredFields, alias, false) {
+			nulled = append(nulled, alias)
 		}
 	}
 	return nulled

--- a/pkg/api-server/lib/v0/context.go
+++ b/pkg/api-server/lib/v0/context.go
@@ -189,6 +189,15 @@ func checkPayloadObject(apiVer string, payloadObject map[string]interface{}, obj
 	optionalFields = &ObjectTaggedFields[VersionObject{Version: apiVer, Object: string(objectType)}].Optional
 	optionalAssociationsFields = &ObjectTaggedFields[VersionObject{Version: apiVer, Object: string(objectType)}].OptionalAssociations
 	requiredFields = &ObjectTaggedFields[VersionObject{Version: apiVer, Object: string(objectType)}].Required
+
+	// reject explicit null on a required field. gorm.Updates(struct)
+	// silently drops nil pointer fields, so the BeforeUpdate relationship
+	// hook never sees the set->nil transition. catching it here enforces
+	// the required contract uniformly across create and update.
+	if nulledRequiredFields := nullValuedRequiredFields(payloadObject, *requiredFields, objectStruct); len(nulledRequiredFields) > 0 {
+		return 400, errors.New(ErrMsgRequiredFieldsCannotBeNull + " : " + strings.Join(nulledRequiredFields, ","))
+	}
+
 	for k, _ := range payloadObject {
 		// check the field k form the payload
 		if !util.StringSliceContains(*optionalFields, k, false) &&
@@ -227,6 +236,29 @@ func readBody(c echo.Context) []byte {
 	bodyBytes, _ := io.ReadAll(c.Request().Body)
 	c.Request().Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	return bodyBytes
+}
+
+// nullValuedRequiredFields returns the Go field names of any required
+// fields that appear in the payload with a JSON null value. Payload
+// keys are matched directly against required field names, or via the
+// `json:` tag alias on the target struct.
+func nullValuedRequiredFields(payloadObject map[string]interface{}, requiredFields []string, objectStruct interface{}) []string {
+	var nulled []string
+	for k, v := range payloadObject {
+		if v != nil {
+			continue
+		}
+		if util.StringSliceContains(requiredFields, k, false) {
+			nulled = append(nulled, k)
+			continue
+		}
+		if alias := getFieldNameByJsonTag(k, "json", objectStruct); alias != "" {
+			if util.StringSliceContains(requiredFields, alias, false) {
+				nulled = append(nulled, alias)
+			}
+		}
+	}
+	return nulled
 }
 
 // getFieldNameByJsonTag returns the field name of the struct by the given tag and key.

--- a/pkg/api-server/lib/v0/context_test.go
+++ b/pkg/api-server/lib/v0/context_test.go
@@ -1,0 +1,68 @@
+package v0
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// payloadCheckTestObject mirrors a typical threeport api type: required
+// pointer FKs without `json:` tags (post tag-normalization) plus an
+// optional pointer. NullableOptional is required but uses a `json:`
+// alias so the helper's alias-lookup path is exercised too.
+type payloadCheckTestObject struct {
+	ID              *uint
+	WorkloadDefID   *uint
+	OptionalStatus  *string
+	NullableAliased *string `json:"nullable_aliased"`
+}
+
+// TestNullValuedRequiredFields covers the three states the helper
+// needs to distinguish on an update payload: a required field with an
+// explicit null value (rejected), a required field omitted from the
+// payload entirely (allowed - gorm just skips it), and a required
+// field whose payload key is the `json:` alias rather than the Go
+// field name (rejected, with the Go field name returned).
+func TestNullValuedRequiredFields(t *testing.T) {
+	required := []string{"WorkloadDefID", "NullableAliased"}
+	obj := payloadCheckTestObject{}
+
+	tests := []struct {
+		name     string
+		payload  map[string]interface{}
+		expected []string
+	}{
+		{
+			name:     "required field set to null is rejected",
+			payload:  map[string]interface{}{"ID": float64(1), "WorkloadDefID": nil},
+			expected: []string{"WorkloadDefID"},
+		},
+		{
+			name:     "required field omitted from payload is allowed",
+			payload:  map[string]interface{}{"ID": float64(1), "OptionalStatus": "ok"},
+			expected: nil,
+		},
+		{
+			name:     "required field set to a value is allowed",
+			payload:  map[string]interface{}{"ID": float64(1), "WorkloadDefID": float64(7)},
+			expected: nil,
+		},
+		{
+			name:     "optional field set to null is allowed",
+			payload:  map[string]interface{}{"ID": float64(1), "OptionalStatus": nil},
+			expected: nil,
+		},
+		{
+			name:     "required field nulled under its json alias is rejected by Go field name",
+			payload:  map[string]interface{}{"nullable_aliased": nil},
+			expected: []string{"NullableAliased"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nullValuedRequiredFields(tc.payload, required, obj)
+			assert.ElementsMatch(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/api-server/lib/v0/context_test.go
+++ b/pkg/api-server/lib/v0/context_test.go
@@ -6,10 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// payloadCheckTestObject mirrors a typical threeport api type: required
-// pointer FKs without `json:` tags (post tag-normalization) plus an
-// optional pointer. NullableOptional is required but uses a `json:`
-// alias so the helper's alias-lookup path is exercised too.
+// payloadCheckTestObject covers the field shapes the helper must
+// handle: required pointer by Go name, optional pointer, and required
+// pointer carrying a json tag alias.
 type payloadCheckTestObject struct {
 	ID              *uint
 	WorkloadDefID   *uint
@@ -17,12 +16,8 @@ type payloadCheckTestObject struct {
 	NullableAliased *string `json:"nullable_aliased"`
 }
 
-// TestNullValuedRequiredFields covers the three states the helper
-// needs to distinguish on an update payload: a required field with an
-// explicit null value (rejected), a required field omitted from the
-// payload entirely (allowed - gorm just skips it), and a required
-// field whose payload key is the `json:` alias rather than the Go
-// field name (rejected, with the Go field name returned).
+// TestNullValuedRequiredFields exercises the payload shapes the
+// helper must distinguish, asserting which trigger rejection.
 func TestNullValuedRequiredFields(t *testing.T) {
 	required := []string{"WorkloadDefID", "NullableAliased"}
 	obj := payloadCheckTestObject{}

--- a/pkg/api-server/lib/v0/response.go
+++ b/pkg/api-server/lib/v0/response.go
@@ -9,6 +9,7 @@ import (
 const (
 	ErrMsgJSONPayloadEmpty                = "JSON payload is empty"
 	ErrMsgMissingRequiredFields           = "Missing required field(s)"
+	ErrMsgRequiredFieldsCannotBeNull      = "Required field(s) cannot be null"
 	ErrMsgAssociationsUpdateNotAllowed    = "Update of associated objects is not allowed. Use PUT for each associated object"
 	ErrMsgGORMModelFieldsUpdateNotAllowed = "Update of GORM Model fields is not allowed"
 	ErrMsgUnsupportedFieldsNotAllowed     = "Unsupported fields are not allowed"

--- a/pkg/api/v0/relationship_hooks_test.go
+++ b/pkg/api/v0/relationship_hooks_test.go
@@ -196,15 +196,10 @@ func TestRelationshipHooks_AfterCreate_AllFourRelationships(t *testing.T) {
 }
 
 // TestRelationshipHooks_BeforeUpdate_FKImmutability walks every
-// relationship FK through every transition kind reachable at the gorm
-// layer: nil->set (allowed) and set->other (rejected on tagged FKs).
-// Untouched FKs stay legal regardless of state. The untagged FK is a
-// negative control - it must remain freely mutable.
-//
-// The set->nil (set->clear) transition is rejected one layer up by
-// PayloadCheck before any gorm call runs, because gorm.Updates(struct)
-// silently drops nil pointer fields. See
-// pkg/api-server/lib/v0/context_test.go::TestNullValuedRequiredFields.
+// relationship FK through gorm-reachable transitions: nil->set
+// allowed, set->other rejected on tagged FKs, set->nil silently
+// dropped by gorm so the FK stays at its pre value. The untagged
+// FK is a negative control, freely mutable.
 func TestRelationshipHooks_BeforeUpdate_FKImmutability(t *testing.T) {
 	type transition struct {
 		name        string
@@ -218,46 +213,68 @@ func TestRelationshipHooks_BeforeUpdate_FKImmutability(t *testing.T) {
 	// a literal table.
 
 	t.Run("RequiresFK", func(t *testing.T) {
-		runFKMatrix(t, "RequiresFK", func(h *testHolder, v *uint) { h.RequiresFK = v }, true)
+		runFKMatrix(t, "RequiresFK",
+			func(h *testHolder, v *uint) { h.RequiresFK = v },
+			func(h *testHolder) *uint { return h.RequiresFK },
+			true,
+		)
 	})
 	t.Run("OwnsFK", func(t *testing.T) {
-		runFKMatrix(t, "OwnsFK", func(h *testHolder, v *uint) { h.OwnsFK = v }, true)
+		runFKMatrix(t, "OwnsFK",
+			func(h *testHolder, v *uint) { h.OwnsFK = v },
+			func(h *testHolder) *uint { return h.OwnsFK },
+			true,
+		)
 	})
 	t.Run("MarriesFK", func(t *testing.T) {
-		runFKMatrix(t, "MarriesFK", func(h *testHolder, v *uint) { h.MarriesFK = v }, true)
+		runFKMatrix(t, "MarriesFK",
+			func(h *testHolder, v *uint) { h.MarriesFK = v },
+			func(h *testHolder) *uint { return h.MarriesFK },
+			true,
+		)
 	})
 	t.Run("DescribesFK", func(t *testing.T) {
-		runFKMatrix(t, "DescribesFK", func(h *testHolder, v *uint) { h.DescribesFK = v }, true)
+		runFKMatrix(t, "DescribesFK",
+			func(h *testHolder, v *uint) { h.DescribesFK = v },
+			func(h *testHolder) *uint { return h.DescribesFK },
+			true,
+		)
 	})
 	t.Run("UntaggedFK_freelyMutable", func(t *testing.T) {
-		runFKMatrix(t, "UntaggedFK", func(h *testHolder, v *uint) { h.UntaggedFK = v }, false)
+		runFKMatrix(t, "UntaggedFK",
+			func(h *testHolder, v *uint) { h.UntaggedFK = v },
+			func(h *testHolder) *uint { return h.UntaggedFK },
+			false,
+		)
 	})
 	_ = transition{}
 }
 
-// runFKMatrix exercises the transitions for one FK field that are
-// reachable through gorm.Updates(struct):
-//   - nil -> set:  allowed
-//   - set -> other: rejected (only for relationship-tagged FKs)
-//   - nil -> nil (untouched, non-FK field changes): allowed
-//   - set -> same (untouched, non-FK field changes): allowed
+// runFKMatrix exercises gorm.Updates(struct) transitions for one FK:
+//   - nil -> set:    allowed
+//   - set -> other:  rejected on tagged FKs
+//   - set -> nil:    gorm drops the nil; FK preserved at pre value
+//   - untouched FKs: allowed regardless of state
 //
-// For an untagged FK (immutable=false), every transition is allowed.
-//
-// The set -> nil case is intentionally absent: gorm.Updates skips nil
-// pointer fields so the SET clause never carries them, and the
-// BeforeUpdate hook's Changed check never fires. That transition is
-// rejected one layer up by PayloadCheck on the raw HTTP body.
-func runFKMatrix(t *testing.T, fkName string, setFK func(*testHolder, *uint), immutable bool) {
+// For an untagged FK (immutable=false), set -> other is allowed too.
+func runFKMatrix(
+	t *testing.T,
+	fkName string,
+	setFK func(*testHolder, *uint),
+	getFK func(*testHolder) *uint,
+	immutable bool,
+) {
 	cases := []struct {
-		name         string
-		preFK        *uint
-		inboundFK    *uint
-		changeName   bool
-		wantRejected bool
+		name            string
+		preFK           *uint
+		inboundFK       *uint
+		changeName      bool
+		wantRejected    bool
+		wantPreservedFK bool
 	}{
 		{name: "nil_to_set", preFK: nil, inboundFK: uintPtr(99), wantRejected: false},
 		{name: "set_to_other", preFK: uintPtr(99), inboundFK: uintPtr(100), wantRejected: immutable},
+		{name: "set_to_nil_gorm_drops_silently", preFK: uintPtr(99), inboundFK: nil, changeName: true, wantRejected: false, wantPreservedFK: true},
 		{name: "untouched_with_name_change", preFK: uintPtr(99), inboundFK: uintPtr(99), changeName: true, wantRejected: false},
 		{name: "nil_untouched_with_name_change", preFK: nil, inboundFK: nil, changeName: true, wantRejected: false},
 	}
@@ -306,8 +323,18 @@ func runFKMatrix(t *testing.T, fkName string, setFK func(*testHolder, *uint), im
 			if tc.wantRejected {
 				require.Error(t, err, "FK %s transition %s should be rejected", fkName, tc.name)
 				assert.Contains(t, err.Error(), "immutable once set", "rejection should cite immutability")
-			} else {
-				require.NoError(t, err, "FK %s transition %s should be allowed", fkName, tc.name)
+				return
+			}
+			require.NoError(t, err, "FK %s transition %s should be allowed", fkName, tc.name)
+
+			// confirm gorm silently dropped the nil from the SET clause
+			// by reloading and checking the FK is unchanged
+			if tc.wantPreservedFK {
+				var post testHolder
+				require.NoError(t, db.First(&post, *existing.ID).Error)
+				postFK := getFK(&post)
+				require.NotNil(t, postFK, "gorm should have dropped nil from SET, leaving FK unchanged")
+				assert.Equal(t, *pre, *postFK, "FK should remain at pre-update value")
 			}
 		})
 	}

--- a/pkg/api/v0/relationship_hooks_test.go
+++ b/pkg/api/v0/relationship_hooks_test.go
@@ -213,9 +213,13 @@ func TestRelationshipHooks_BeforeUpdate_FKImmutability(t *testing.T) {
 	// a literal table.
 
 	t.Run("RequiresFK", func(t *testing.T) {
+		// run the shared transition matrix against the RequiresFK field
 		runFKMatrix(t, "RequiresFK",
+			// setter: write v into RequiresFK; lets runFKMatrix populate the field generically
 			func(h *testHolder, v *uint) { h.RequiresFK = v },
+			// getter: read RequiresFK back; lets runFKMatrix verify post-update state generically
 			func(h *testHolder) *uint { return h.RequiresFK },
+			// immutable=true: relationship-tagged FK, so set->other transitions must be rejected
 			true,
 		)
 	})

--- a/pkg/api/v0/relationship_hooks_test.go
+++ b/pkg/api/v0/relationship_hooks_test.go
@@ -196,11 +196,15 @@ func TestRelationshipHooks_AfterCreate_AllFourRelationships(t *testing.T) {
 }
 
 // TestRelationshipHooks_BeforeUpdate_FKImmutability walks every
-// relationship FK through every transition kind. Production behavior:
-// the initial nil->set is allowed; any subsequent change (set->other
-// or set->clear) is rejected with a bad-request error. Untouched FKs
-// stay legal regardless of state. The untagged FK is a negative
-// control - it must remain freely mutable.
+// relationship FK through every transition kind reachable at the gorm
+// layer: nil->set (allowed) and set->other (rejected on tagged FKs).
+// Untouched FKs stay legal regardless of state. The untagged FK is a
+// negative control - it must remain freely mutable.
+//
+// The set->nil (set->clear) transition is rejected one layer up by
+// PayloadCheck before any gorm call runs, because gorm.Updates(struct)
+// silently drops nil pointer fields. See
+// pkg/api-server/lib/v0/context_test.go::TestNullValuedRequiredFields.
 func TestRelationshipHooks_BeforeUpdate_FKImmutability(t *testing.T) {
 	type transition struct {
 		name        string
@@ -231,24 +235,29 @@ func TestRelationshipHooks_BeforeUpdate_FKImmutability(t *testing.T) {
 	_ = transition{}
 }
 
-// runFKMatrix exercises the four transitions for one FK field:
+// runFKMatrix exercises the transitions for one FK field that are
+// reachable through gorm.Updates(struct):
 //   - nil -> set:  allowed
 //   - set -> other: rejected (only for relationship-tagged FKs)
-//   - set -> nil:   rejected (only for relationship-tagged FKs)
 //   - nil -> nil (untouched, non-FK field changes): allowed
+//   - set -> same (untouched, non-FK field changes): allowed
 //
 // For an untagged FK (immutable=false), every transition is allowed.
+//
+// The set -> nil case is intentionally absent: gorm.Updates skips nil
+// pointer fields so the SET clause never carries them, and the
+// BeforeUpdate hook's Changed check never fires. That transition is
+// rejected one layer up by PayloadCheck on the raw HTTP body.
 func runFKMatrix(t *testing.T, fkName string, setFK func(*testHolder, *uint), immutable bool) {
 	cases := []struct {
-		name        string
-		preFK       *uint
-		inboundFK   *uint
-		changeName  bool
+		name         string
+		preFK        *uint
+		inboundFK    *uint
+		changeName   bool
 		wantRejected bool
 	}{
 		{name: "nil_to_set", preFK: nil, inboundFK: uintPtr(99), wantRejected: false},
 		{name: "set_to_other", preFK: uintPtr(99), inboundFK: uintPtr(100), wantRejected: immutable},
-		{name: "set_to_nil", preFK: uintPtr(99), inboundFK: nil, wantRejected: immutable},
 		{name: "untouched_with_name_change", preFK: uintPtr(99), inboundFK: uintPtr(99), changeName: true, wantRejected: false},
 		{name: "nil_untouched_with_name_change", preFK: nil, inboundFK: nil, changeName: true, wantRejected: false},
 	}
@@ -292,16 +301,7 @@ func runFKMatrix(t *testing.T, fkName string, setFK func(*testHolder, *uint), im
 				inbound.Name = strPtr("renamed")
 			}
 
-			// gorm's Updates(&struct) skips zero-valued pointer fields, so
-			// the SET clause wouldn't include a nil-cleared FK. Force the
-			// field into the SET via Select for the set_to_nil case so the
-			// hook's Changed check fires and exercises the defensive
-			// rejection branch.
-			updater := db.Model(&loaded)
-			if tc.name == "set_to_nil" {
-				updater = updater.Select(fkName)
-			}
-			err := updater.Updates(inbound).Error
+			err := db.Model(&loaded).Updates(inbound).Error
 
 			if tc.wantRejected {
 				require.Error(t, err, "FK %s transition %s should be rejected", fkName, tc.name)


### PR DESCRIPTION
Reject explicit `null` on `validate:"required"` fields in `PayloadCheck` before bind. Previously a PATCH like `{"WorkloadDefinitionID": null}` returned 200 with no actual change: bind turned the null into a nil `*uint`, gorm's `Updates(struct)` skipped it because nil pointers don't enter the SET clause, and the `BeforeUpdate` relationship hook's `Changed` check never fired. The new helper walks the parsed payload map (where JSON null is still distinguishable from "field omitted") and reports any required field set to null, by Go field name even when the wire key uses a `json:` alias. Applies to both create and update.

The companion test in `relationship_hooks_test.go` drops a `Select(fkName)` cheat that faked the now-unreachable set-to-nil case at the gorm layer, and replaces it with a `set_to_nil_gorm_drops_silently` case that pins gorm's drop-nil behavior, so a future gorm upgrade that changed nil-pointer handling would fail the test rather than silently bypass the new guard.