### PR TITLE
feat: parallel image builds in mage AllImagesDev/Release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       run: mage dev:localRegistryUp
 
     - name: Build and push control plane component images
-      run: mage build:allImagesDev 8
+      run: mage build:allImagesDev 4
 
     - name: Build tptctl
       run: mage build:tptctl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,13 @@ jobs:
     - name: Create local container registry
       run: mage dev:localRegistryUp
 
+    - name: Build tptdev
+      run: mage build:tptdev
+
     - name: Build and push control plane component images
-      run: mage build:allImagesDev
+      run: |
+        VERSION=$(tr -d '\n' < internal/version/version.txt)
+        ./bin/tptdev build --push -r localhost:5001 -t "$VERSION" --parallel 4
 
     - name: Build tptctl
       run: mage build:tptctl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,13 +40,8 @@ jobs:
     - name: Create local container registry
       run: mage dev:localRegistryUp
 
-    - name: Build tptdev
-      run: mage build:tptdev
-
     - name: Build and push control plane component images
-      run: |
-        VERSION=$(tr -d '\n' < internal/version/version.txt)
-        ./bin/tptdev build --push -r localhost:5001 -t "$VERSION" --parallel 4
+      run: mage build:allImagesDev 8
 
     - name: Build tptctl
       run: mage build:tptctl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       run: mage dev:localRegistryUp
 
     - name: Build and push control plane component images
-      run: mage build:allImagesDev 4
+      run: mage build:allImagesDev 2
 
     - name: Build tptctl
       run: mage build:tptctl

--- a/magefiles/magefile_gen.go
+++ b/magefiles/magefile_gen.go
@@ -1877,127 +1877,49 @@ func (Build) AllImages(
 }
 
 // AllImagesDev builds and pushes development images for all components.
-func (Build) AllImagesDev() error {
+// Pass parallel >= 1 to control worker concurrency (e.g. `mage build:allImagesDev 4`).
+func (Build) AllImagesDev(parallel int) error {
 	build := Build{}
-	if err := build.ApiImageDev(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
+	tasks := []func() error{
+		build.ApiImageDev,
+		build.DbMigratorImageDev,
+		build.AgentImageDev,
+		build.SecretControllerImageDev,
+		build.AwsControllerImageDev,
+		build.OciControllerImageDev,
+		build.GcpControllerImageDev,
+		build.ControlPlaneControllerImageDev,
+		build.GatewayControllerImageDev,
+		build.HelmWorkloadControllerImageDev,
+		build.KubernetesRuntimeControllerImageDev,
+		build.ObservabilityControllerImageDev,
+		build.TerraformControllerImageDev,
+		build.WorkloadControllerImageDev,
 	}
-
-	if err := build.DbMigratorImageDev(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.AgentImageDev(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.SecretControllerImageDev(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.AwsControllerImageDev(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.OciControllerImageDev(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.GcpControllerImageDev(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.ControlPlaneControllerImageDev(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.GatewayControllerImageDev(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.HelmWorkloadControllerImageDev(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.KubernetesRuntimeControllerImageDev(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.ObservabilityControllerImageDev(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.TerraformControllerImageDev(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.WorkloadControllerImageDev(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	return nil
+	return util.RunParallel(parallel, tasks)
 }
 
-// AllImagesRelease builds and pushes development images for all components.
-func (Build) AllImagesRelease() error {
+// AllImagesRelease builds and pushes release images for all components.
+// Pass parallel >= 1 to control worker concurrency (e.g. `mage build:allImagesRelease 4`).
+func (Build) AllImagesRelease(parallel int) error {
 	build := Build{}
-	if err := build.ApiImageRelease(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
+	tasks := []func() error{
+		build.ApiImageRelease,
+		build.DbMigratorImageRelease,
+		build.AgentImageRelease,
+		build.SecretControllerImageRelease,
+		build.AwsControllerImageRelease,
+		build.OciControllerImageRelease,
+		build.GcpControllerImageRelease,
+		build.ControlPlaneControllerImageRelease,
+		build.GatewayControllerImageRelease,
+		build.HelmWorkloadControllerImageRelease,
+		build.KubernetesRuntimeControllerImageRelease,
+		build.ObservabilityControllerImageRelease,
+		build.TerraformControllerImageRelease,
+		build.WorkloadControllerImageRelease,
 	}
-
-	if err := build.DbMigratorImageRelease(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.AgentImageRelease(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.SecretControllerImageRelease(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.AwsControllerImageRelease(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.OciControllerImageRelease(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.GcpControllerImageRelease(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.ControlPlaneControllerImageRelease(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.GatewayControllerImageRelease(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.HelmWorkloadControllerImageRelease(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.KubernetesRuntimeControllerImageRelease(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.ObservabilityControllerImageRelease(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.TerraformControllerImageRelease(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	if err := build.WorkloadControllerImageRelease(); err != nil {
-		return fmt.Errorf("failed to build and push image: %w", err)
-	}
-
-	return nil
+	return util.RunParallel(parallel, tasks)
 }
 
 // LoadImage builds and loads an image to the provided kind cluster.

--- a/pkg/sdk/v0/gen/root/magefile.go
+++ b/pkg/sdk/v0/gen/root/magefile.go
@@ -938,37 +938,37 @@ func GenMagefile(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 	// build and push all dev images
 	buildAllDevImagesFuncName := "AllImagesDev"
 	f.Comment(fmt.Sprintf("%s builds and pushes development images for all components.", buildAllDevImagesFuncName))
-	f.Func().Params(Id("Build")).Id(buildAllDevImagesFuncName).Params().Error().BlockFunc(func(g *Group) {
+	f.Comment("Pass parallel >= 1 to control worker concurrency (e.g. `mage build:allImagesDev 4`).")
+	f.Func().Params(Id("Build")).Id(buildAllDevImagesFuncName).Params(Id("parallel").Int()).Error().BlockFunc(func(g *Group) {
 		g.Id("build").Op(":=").Id("Build").Values()
-		for _, funcName := range buildDevImageFuncNames {
-			g.If(Err().Op(":=").Id("build").Dot(funcName).Call().Op(";").Err().Op("!=").Nil()).Block(
-				Return().Qual("fmt", "Errorf").Call(
-					Lit("failed to build and push image: %w"),
-					Err(),
-				),
-			)
-			g.Line()
-		}
-
-		g.Return().Nil()
+		g.Id("tasks").Op(":=").Index().Func().Params().Error().ValuesFunc(func(v *Group) {
+			for _, funcName := range buildDevImageFuncNames {
+				v.Line().Id("build").Dot(funcName)
+			}
+			v.Line()
+		})
+		g.Return().Qual("github.com/threeport/threeport/pkg/util/v0", "RunParallel").Call(
+			Id("parallel"),
+			Id("tasks"),
+		)
 	})
 
 	// build and push all release images
 	buildAllReleaseImagesFuncName := "AllImagesRelease"
-	f.Comment(fmt.Sprintf("%s builds and pushes development images for all components.", buildAllReleaseImagesFuncName))
-	f.Func().Params(Id("Build")).Id(buildAllReleaseImagesFuncName).Params().Error().BlockFunc(func(g *Group) {
+	f.Comment(fmt.Sprintf("%s builds and pushes release images for all components.", buildAllReleaseImagesFuncName))
+	f.Comment("Pass parallel >= 1 to control worker concurrency (e.g. `mage build:allImagesRelease 4`).")
+	f.Func().Params(Id("Build")).Id(buildAllReleaseImagesFuncName).Params(Id("parallel").Int()).Error().BlockFunc(func(g *Group) {
 		g.Id("build").Op(":=").Id("Build").Values()
-		for _, funcName := range buildReleaseImageFuncNames {
-			g.If(Err().Op(":=").Id("build").Dot(funcName).Call().Op(";").Err().Op("!=").Nil()).Block(
-				Return().Qual("fmt", "Errorf").Call(
-					Lit("failed to build and push image: %w"),
-					Err(),
-				),
-			)
-			g.Line()
-		}
-
-		g.Return().Nil()
+		g.Id("tasks").Op(":=").Index().Func().Params().Error().ValuesFunc(func(v *Group) {
+			for _, funcName := range buildReleaseImageFuncNames {
+				v.Line().Id("build").Dot(funcName)
+			}
+			v.Line()
+		})
+		g.Return().Qual("github.com/threeport/threeport/pkg/util/v0", "RunParallel").Call(
+			Id("parallel"),
+			Id("tasks"),
+		)
 	})
 
 	// dev image loads to kind clusters

--- a/pkg/util/v0/parallel.go
+++ b/pkg/util/v0/parallel.go
@@ -1,0 +1,41 @@
+package v0
+
+import "sync"
+
+// RunParallel executes tasks concurrently with the given worker count.
+// All tasks run regardless of whether one fails; errors are aggregated
+// via MultiError. A parallel value of 1 (or less) collapses to a
+// single sequential worker. Designed to match the worker-pool shape
+// in tptdev's build command so the two can converge later.
+func RunParallel(parallel int, tasks []func() error) error {
+	if parallel < 1 {
+		parallel = 1
+	}
+
+	jobs := make(chan func() error)
+	var wg sync.WaitGroup
+	var errMu sync.Mutex
+	var multi MultiError
+
+	for i := 0; i < parallel; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for task := range jobs {
+				if err := task(); err != nil {
+					errMu.Lock()
+					multi.AppendError(err)
+					errMu.Unlock()
+				}
+			}
+		}()
+	}
+
+	for _, task := range tasks {
+		jobs <- task
+	}
+	close(jobs)
+	wg.Wait()
+
+	return multi.Error()
+}


### PR DESCRIPTION
Adds parallel image build support to mage's AllImagesDev and AllImagesRelease via a new RunParallel util that mirrors tptdev build's worker-pool shape. Each worker pipelines build then push per component, so a fast image publishes before slower ones finish. CI now uses mage build:allImagesDev 8.