### PR TITLE
feat: add --apis flag for selective controller install

### DIFF
--- a/cmd/tptctl/cmd/up.go
+++ b/cmd/tptctl/cmd/up.go
@@ -18,9 +18,9 @@ import (
 	threeport "github.com/threeport/threeport/pkg/threeport-installer/v0"
 )
 
-// upGroupNames holds the --names flag value: a comma-separated list
+// upApis holds the --apis flag value: a comma-separated list
 // of sdk-config ApiObjectGroup names whose controllers to install.
-var upGroupNames string
+var upApis string
 
 // TODO: will become a variable once production-ready control plane instances are
 // available.
@@ -98,12 +98,12 @@ control planes if they are used to create or are created by another control plan
 			os.Exit(1)
 		}
 
-		// narrow the controller list when --names is set so the install
-		// brings up only the requested groups' controllers alongside the
+		// narrow the controller list when --apis is set so the install
+		// brings up only the requested apis' controllers alongside the
 		// rest-api and agent.
-		if upGroupNames != "" {
+		if upApis != "" {
 			selected, err := threeport.SelectControllersByGroup(
-				parseUpGroupNames(upGroupNames),
+				parseUpApis(upApis),
 				cpi.Opts.ControllerList,
 			)
 			if err != nil {
@@ -236,18 +236,18 @@ func init() {
 		"kind-port-mappings", []string{}, "Port mappings for kind provider. Format: <container-port>:<host-port>,<container-port>:<host-port>,...",
 	)
 	UpCmd.Flags().StringVar(
-		&upGroupNames,
-		"names", "",
-		"Comma-separated sdk-config ApiObjectGroup names (e.g. kubernetes_workload,gateway) "+
+		&upApis,
+		"apis", "",
+		"Comma-separated sdk-config api names (e.g. kubernetes_workload,gateway) "+
 			"whose controllers to install. NOT component names. When omitted, installs the "+
 			"full default controller list.",
 	)
 }
 
-// parseUpGroupNames splits the --names flag value on commas and trims
+// parseUpApis splits the --apis flag value on commas and trims
 // whitespace from each entry, dropping empty fragments produced by
 // leading or trailing commas.
-func parseUpGroupNames(value string) []string {
+func parseUpApis(value string) []string {
 	if value == "" {
 		return nil
 	}

--- a/cmd/tptctl/cmd/up.go
+++ b/cmd/tptctl/cmd/up.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -16,6 +17,10 @@ import (
 	cli "github.com/threeport/threeport/pkg/cli/v0"
 	threeport "github.com/threeport/threeport/pkg/threeport-installer/v0"
 )
+
+// upGroupNames holds the --names flag value: a comma-separated list
+// of sdk-config ApiObjectGroup names whose controllers to install.
+var upGroupNames string
 
 // TODO: will become a variable once production-ready control plane instances are
 // available.
@@ -91,6 +96,29 @@ control planes if they are used to create or are created by another control plan
 		if err != nil {
 			cli.Error("failed to create threeport control plane installer", err)
 			os.Exit(1)
+		}
+
+		// narrow the controller list when --names is set so the install
+		// brings up only the requested groups' controllers alongside the
+		// rest-api and agent.
+		if upGroupNames != "" {
+			selected, err := threeport.SelectControllersByGroup(
+				parseUpGroupNames(upGroupNames),
+				cpi.Opts.ControllerList,
+			)
+			if err != nil {
+				cli.Error("failed to select controllers", err)
+				os.Exit(1)
+			}
+			selectedNames := make([]string, 0, len(selected))
+			for _, controller := range selected {
+				selectedNames = append(selectedNames, controller.Name)
+			}
+			cli.Info(fmt.Sprintf(
+				"limiting install to %d controller(s): %s",
+				len(selected), strings.Join(selectedNames, ", "),
+			))
+			cpi.Opts.ControllerList = selected
 		}
 
 		err = cli.CreateGenesisControlPlane(cpi)
@@ -207,4 +235,29 @@ func init() {
 		&cliArgs.KindPortMappings,
 		"kind-port-mappings", []string{}, "Port mappings for kind provider. Format: <container-port>:<host-port>,<container-port>:<host-port>,...",
 	)
+	UpCmd.Flags().StringVar(
+		&upGroupNames,
+		"names", "",
+		"Comma-separated sdk-config ApiObjectGroup names (e.g. kubernetes_workload,gateway) "+
+			"whose controllers to install. NOT component names. When omitted, installs the "+
+			"full default controller list.",
+	)
+}
+
+// parseUpGroupNames splits the --names flag value on commas and trims
+// whitespace from each entry, dropping empty fragments produced by
+// leading or trailing commas.
+func parseUpGroupNames(value string) []string {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }

--- a/cmd/tptdev/cmd/reinstall.go
+++ b/cmd/tptdev/cmd/reinstall.go
@@ -1,0 +1,113 @@
+/*
+Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	auth "github.com/threeport/threeport/pkg/auth/v0"
+	cli "github.com/threeport/threeport/pkg/cli/v0"
+	client_lib "github.com/threeport/threeport/pkg/client/lib/v0"
+	installer "github.com/threeport/threeport/pkg/threeport-installer/v0"
+	"github.com/threeport/threeport/pkg/threeport-installer/v0/tptdev"
+)
+
+// reinstallCmd represents the reinstall command. Dev-only: sweeps
+// installer-managed stateless deployments and reapplies the install
+// path so devs pick up source changes without losing database state
+// or rotating the control plane's external endpoint.
+var reinstallCmd = &cobra.Command{
+	Use:   "reinstall",
+	Short: "Sweep and reapply stateless control plane resources",
+	Long: `Reinstall the stateless side of a dev threeport control plane.
+
+Sweeps every installer-managed Deployment in the control plane
+namespace, then reapplies the install path so the pods come back with
+the current images and specs from source.
+
+Preserved across reinstall: cockroachdb data, nats data, the
+certificate authority and signed certs, and the rest-api's external
+service ip. Everything else (controller and api-server pods, their
+configmaps, rbac) is recreated.
+
+Intended for dev environments only. The reinstall command does not
+build images; run 'tptdev build --push' first if the image needs to
+change.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cliArgs.GetControlPlaneEnvVars()
+
+		// default tag to current git branch name so reinstall picks up
+		// images built by 'tptdev build' without requiring --tag every
+		// invocation; matches the build command's default.
+		if cliArgs.ControlPlaneImageTag == "" {
+			branch, err := gitBranchName()
+			if err != nil {
+				cli.Error(fmt.Sprintf("failed to determine git branch for default tag: %s\nspecify a tag explicitly with --tag/-t", err), nil)
+				os.Exit(1)
+			}
+			cliArgs.ControlPlaneImageTag = branch
+		}
+
+		cpi, err := cliArgs.CreateInstaller()
+		if err != nil {
+			cli.Error("failed to create threeport control plane installer", err)
+			os.Exit(1)
+		}
+		cpi.Opts.Namespace = installer.ControlPlaneNamespace
+
+		kubeClient, mapper, err := client_lib.GetKubeDynamicClientAndMapper(cliArgs.KubeconfigPath)
+		if err != nil {
+			cli.Error("failed to create kube client", err)
+			os.Exit(1)
+		}
+
+		// detect whether the running api was installed with auth so the
+		// reapply path configures the new pods the same way
+		cpi.Opts.AuthEnabled = detectAuthEnabled(kubeClient)
+
+		// load the existing CA from the cluster when auth is on so
+		// controllers added since the original install get fresh
+		// certs signed by the persistent CA. existing controllers'
+		// cert secrets survive the sweep and are reused as-is.
+		var authConfig *auth.AuthConfig
+		if cpi.Opts.AuthEnabled {
+			authConfig, err = cpi.LoadAuthConfigFromCluster(kubeClient, &mapper)
+			if err != nil {
+				cli.Error("failed to load existing CA from cluster", err)
+				os.Exit(1)
+			}
+		}
+
+		if err := cpi.Reinstall(kubeClient, &mapper, authConfig); err != nil {
+			cli.Error("failed to reinstall threeport control plane", err)
+			os.Exit(1)
+		}
+
+		cli.Complete("threeport control plane reinstalled")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(reinstallCmd)
+
+	reinstallCmd.Flags().StringVarP(
+		&cliArgs.ControlPlaneName,
+		"name", "n", tptdev.DefaultInstanceName, "Name of dev genesis control plane.",
+	)
+	reinstallCmd.Flags().StringVarP(
+		&cliArgs.KubeconfigPath,
+		"kubeconfig", "k", "", "Path to kubeconfig (default is ~/.kube/config).",
+	)
+	reinstallCmd.Flags().StringVarP(
+		&cliArgs.ControlPlaneImageRepo,
+		"control-plane-image-namespace", "r", "", "Image namespace to pull threeport control plane images from.",
+	)
+	reinstallCmd.Flags().StringVarP(
+		&cliArgs.ControlPlaneImageTag,
+		"control-plane-image-tag", "t", "", "Image tag for threeport control plane images. Defaults to the current git branch name.",
+	)
+}

--- a/cmd/tptdev/cmd/reinstall.go
+++ b/cmd/tptdev/cmd/reinstall.go
@@ -17,10 +17,10 @@ import (
 	"github.com/threeport/threeport/pkg/threeport-installer/v0/tptdev"
 )
 
-// reinstallGroupNames holds the --names flag value: a comma-separated
+// reinstallApis holds the --apis flag value: a comma-separated
 // list of sdk-config ApiObjectGroup names whose controllers should be
 // reinstalled.
-var reinstallGroupNames string
+var reinstallApis string
 
 // reinstallCmd represents the reinstall command. Dev-only: sweeps
 // installer-managed stateless deployments and reapplies the install
@@ -90,13 +90,13 @@ change.`,
 		}
 
 		// narrow the controller list to either the explicitly requested
-		// groups or, when --names is omitted, whatever's already in the
+		// apis or, when --apis is omitted, whatever's already in the
 		// cluster so iterative dev reinstalls don't re-add controllers
 		// the user previously dropped.
 		selected, selectedNames, detected, err := installer.SelectControllersForReinstall(
 			kubeClient,
 			cpi.Opts.Namespace,
-			parseGroupNames(reinstallGroupNames),
+			parseApis(reinstallApis),
 			cpi.Opts.ControllerList,
 		)
 		if err != nil {
@@ -149,18 +149,18 @@ func init() {
 		"debug", false, "If true, pod imagePullPolicy is set to Always so each rollout re-pulls the tag.",
 	)
 	reinstallCmd.Flags().StringVar(
-		&reinstallGroupNames,
-		"names", "",
-		"Comma-separated sdk-config ApiObjectGroup names (e.g. kubernetes_workload,gateway) "+
+		&reinstallApis,
+		"apis", "",
+		"Comma-separated sdk-config api names (e.g. kubernetes_workload,gateway) "+
 			"whose controllers to reinstall. NOT component names. When omitted, defaults to "+
 			"whatever's currently deployed in the cluster.",
 	)
 }
 
-// parseGroupNames splits the --names flag value on commas and trims
+// parseApis splits the --apis flag value on commas and trims
 // whitespace from each entry, dropping empty fragments produced by
 // leading or trailing commas.
-func parseGroupNames(value string) []string {
+func parseApis(value string) []string {
 	if value == "" {
 		return nil
 	}

--- a/cmd/tptdev/cmd/reinstall.go
+++ b/cmd/tptdev/cmd/reinstall.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -15,6 +16,11 @@ import (
 	installer "github.com/threeport/threeport/pkg/threeport-installer/v0"
 	"github.com/threeport/threeport/pkg/threeport-installer/v0/tptdev"
 )
+
+// reinstallGroupNames holds the --names flag value: a comma-separated
+// list of sdk-config ApiObjectGroup names whose controllers should be
+// reinstalled.
+var reinstallGroupNames string
 
 // reinstallCmd represents the reinstall command. Dev-only: sweeps
 // installer-managed stateless deployments and reapplies the install
@@ -83,6 +89,33 @@ change.`,
 			}
 		}
 
+		// narrow the controller list to either the explicitly requested
+		// groups or, when --names is omitted, whatever's already in the
+		// cluster so iterative dev reinstalls don't re-add controllers
+		// the user previously dropped.
+		selected, selectedNames, detected, err := installer.SelectControllersForReinstall(
+			kubeClient,
+			cpi.Opts.Namespace,
+			parseGroupNames(reinstallGroupNames),
+			cpi.Opts.ControllerList,
+		)
+		if err != nil {
+			cli.Error("failed to select controllers for reinstall", err)
+			os.Exit(1)
+		}
+		if detected {
+			cli.Info(fmt.Sprintf(
+				"auto-detected %d installed controller(s) from cluster: %s",
+				len(selectedNames), strings.Join(selectedNames, ", "),
+			))
+		} else {
+			cli.Info(fmt.Sprintf(
+				"limiting reinstall to %d controller(s): %s",
+				len(selectedNames), strings.Join(selectedNames, ", "),
+			))
+		}
+		cpi.Opts.ControllerList = selected
+
 		if err := cpi.Reinstall(kubeClient, &mapper, authConfig); err != nil {
 			cli.Error("failed to reinstall threeport control plane", err)
 			os.Exit(1)
@@ -115,4 +148,29 @@ func init() {
 		&cliArgs.Debug,
 		"debug", false, "If true, pod imagePullPolicy is set to Always so each rollout re-pulls the tag.",
 	)
+	reinstallCmd.Flags().StringVar(
+		&reinstallGroupNames,
+		"names", "",
+		"Comma-separated sdk-config ApiObjectGroup names (e.g. kubernetes_workload,gateway) "+
+			"whose controllers to reinstall. NOT component names. When omitted, defaults to "+
+			"whatever's currently deployed in the cluster.",
+	)
+}
+
+// parseGroupNames splits the --names flag value on commas and trims
+// whitespace from each entry, dropping empty fragments produced by
+// leading or trailing commas.
+func parseGroupNames(value string) []string {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }

--- a/cmd/tptdev/cmd/reinstall.go
+++ b/cmd/tptdev/cmd/reinstall.go
@@ -58,6 +58,7 @@ change.`,
 			os.Exit(1)
 		}
 		cpi.Opts.Namespace = installer.ControlPlaneNamespace
+		cpi.Opts.Debug = cliArgs.Debug
 
 		kubeClient, mapper, err := client_lib.GetKubeDynamicClientAndMapper(cliArgs.KubeconfigPath)
 		if err != nil {
@@ -109,5 +110,9 @@ func init() {
 	reinstallCmd.Flags().StringVarP(
 		&cliArgs.ControlPlaneImageTag,
 		"control-plane-image-tag", "t", "", "Image tag for threeport control plane images. Defaults to the current git branch name.",
+	)
+	reinstallCmd.Flags().BoolVar(
+		&cliArgs.Debug,
+		"debug", false, "If true, pod imagePullPolicy is set to Always so each rollout re-pulls the tag.",
 	)
 }

--- a/cmd/tptdev/cmd/up.go
+++ b/cmd/tptdev/cmd/up.go
@@ -5,13 +5,20 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	cli "github.com/threeport/threeport/pkg/cli/v0"
+	installer "github.com/threeport/threeport/pkg/threeport-installer/v0"
 	"github.com/threeport/threeport/pkg/threeport-installer/v0/tptdev"
 )
+
+// upGroupNames holds the --names flag value: a comma-separated list
+// of sdk-config ApiObjectGroup names whose controllers to install.
+var upGroupNames string
 
 // upCmd represents the up command
 var upCmd = &cobra.Command{
@@ -28,6 +35,29 @@ var upCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		cpi.Opts.Debug = cliArgs.Debug
+
+		// narrow the controller list when --names is set so the install
+		// brings up only the requested groups' controllers alongside the
+		// rest-api and agent.
+		if upGroupNames != "" {
+			selected, err := installer.SelectControllersByGroup(
+				parseGroupNames(upGroupNames),
+				cpi.Opts.ControllerList,
+			)
+			if err != nil {
+				cli.Error("failed to select controllers", err)
+				os.Exit(1)
+			}
+			selectedNames := make([]string, 0, len(selected))
+			for _, controller := range selected {
+				selectedNames = append(selectedNames, controller.Name)
+			}
+			cli.Info(fmt.Sprintf(
+				"limiting install to %d controller(s): %s",
+				len(selected), strings.Join(selectedNames, ", "),
+			))
+			cpi.Opts.ControllerList = selected
+		}
 
 		err = cli.CreateGenesisControlPlane(cpi)
 		if err != nil {
@@ -107,6 +137,13 @@ func init() {
 	upCmd.Flags().BoolVar(
 		&cliArgs.LocalRegistry,
 		"local-registry", false, "Connects a local container registry to Threeport control plane cluster.  Only applicable with provider 'kind'.",
+	)
+	upCmd.Flags().StringVar(
+		&upGroupNames,
+		"names", "",
+		"Comma-separated sdk-config ApiObjectGroup names (e.g. kubernetes_workload,gateway) "+
+			"whose controllers to install. NOT component names. When omitted, installs the "+
+			"full default controller list.",
 	)
 	cobra.OnInitialize(func() {
 		cli.InitConfig(upCmd, cliArgs.CfgFile)

--- a/cmd/tptdev/cmd/up.go
+++ b/cmd/tptdev/cmd/up.go
@@ -16,9 +16,9 @@ import (
 	"github.com/threeport/threeport/pkg/threeport-installer/v0/tptdev"
 )
 
-// upGroupNames holds the --names flag value: a comma-separated list
+// upApis holds the --apis flag value: a comma-separated list
 // of sdk-config ApiObjectGroup names whose controllers to install.
-var upGroupNames string
+var upApis string
 
 // upCmd represents the up command
 var upCmd = &cobra.Command{
@@ -36,12 +36,12 @@ var upCmd = &cobra.Command{
 		}
 		cpi.Opts.Debug = cliArgs.Debug
 
-		// narrow the controller list when --names is set so the install
-		// brings up only the requested groups' controllers alongside the
+		// narrow the controller list when --apis is set so the install
+		// brings up only the requested apis' controllers alongside the
 		// rest-api and agent.
-		if upGroupNames != "" {
+		if upApis != "" {
 			selected, err := installer.SelectControllersByGroup(
-				parseGroupNames(upGroupNames),
+				parseApis(upApis),
 				cpi.Opts.ControllerList,
 			)
 			if err != nil {
@@ -139,9 +139,9 @@ func init() {
 		"local-registry", false, "Connects a local container registry to Threeport control plane cluster.  Only applicable with provider 'kind'.",
 	)
 	upCmd.Flags().StringVar(
-		&upGroupNames,
-		"names", "",
-		"Comma-separated sdk-config ApiObjectGroup names (e.g. kubernetes_workload,gateway) "+
+		&upApis,
+		"apis", "",
+		"Comma-separated sdk-config api names (e.g. kubernetes_workload,gateway) "+
 			"whose controllers to install. NOT component names. When omitted, installs the "+
 			"full default controller list.",
 	)

--- a/pkg/threeport-installer/v0/components.go
+++ b/pkg/threeport-installer/v0/components.go
@@ -114,6 +114,7 @@ func (cpi *ControlPlaneInstaller) UpdateThreeportAPIDeployment(
 			},
 		}
 
+		setPersistent(dbRootCertsSecret)
 		if err := cpi.CreateOrUpdateKubeResource(dbRootCertsSecret, kubeClient, mapper); err != nil {
 			return fmt.Errorf("failed to create DB root user certs secret: %w", err)
 		}
@@ -136,6 +137,7 @@ func (cpi *ControlPlaneInstaller) UpdateThreeportAPIDeployment(
 			},
 		}
 
+		setPersistent(dbThreeportCertsSecret)
 		if err := cpi.CreateOrUpdateKubeResource(dbThreeportCertsSecret, kubeClient, mapper); err != nil {
 			return fmt.Errorf("failed to create DB threeport user certs secret: %w", err)
 		}
@@ -327,7 +329,6 @@ func (cpi *ControlPlaneInstaller) InstallThreeportAPITLS(
 	serverAltNames ...string,
 ) error {
 	if authConfig != nil {
-		// generate server certificate
 		serverCertificate, serverPrivateKey, err := auth.GenerateCertificate(
 			authConfig.CAConfig,
 			&authConfig.CAPrivateKey,
@@ -340,6 +341,11 @@ func (cpi *ControlPlaneInstaller) InstallThreeportAPITLS(
 			return fmt.Errorf("failed to generate server certificate and private key: %w", err)
 		}
 
+		// the api ca and api-cert carry the persistent label, so
+		// CreateOrUpdateKubeResource skips them when they already
+		// exist - reinstall keeps the cluster's CA fingerprint and
+		// the api's server identity stable, even though we redundantly
+		// generated a fresh cert above (cheap, dev-only path).
 		var apiCa = cpi.getTLSSecret(ThreeportApiCaSecret, authConfig.CAPemEncoded, authConfig.CAPrivateKeyPemEncoded)
 		if err := cpi.CreateOrUpdateKubeResource(apiCa, kubeClient, mapper); err != nil {
 			return fmt.Errorf("failed to create API server ca secret: %w", err)
@@ -371,8 +377,13 @@ func (cpi *ControlPlaneInstaller) InstallThreeportControllers(
 			continue
 		}
 
-		// if auth is enabled on API, generate client cert and key and store in
-		// secrets
+		// if auth is enabled, sign a client cert per controller. the
+		// per-controller `<name>-ca` and `<name>-cert` Secrets carry
+		// the persistent label, so CreateOrUpdateKubeResource skips
+		// them when they already exist. only new controllers (added
+		// since the last install) actually land a fresh cert; the
+		// generate step above is cheap and redundant for the existing
+		// ones.
 		if authConfig != nil {
 			certificate, privateKey, err := auth.GenerateCertificate(
 				authConfig.CAConfig,
@@ -399,6 +410,7 @@ func (cpi *ControlPlaneInstaller) InstallThreeportControllers(
 					},
 				},
 			}
+			setPersistent(ca)
 			if err := cpi.CreateOrUpdateKubeResource(ca, kubeClient, mapper); err != nil {
 				return fmt.Errorf("failed to create API server ca secret for workload controller: %w", err)
 			}
@@ -446,11 +458,32 @@ func (cpi *ControlPlaneInstaller) InstallThreeportControllers(
 }
 
 // CreateOrUpdateKubeResource creates or updates a Kubernetes resource.
+// Resources marked with the persistent label are create-only: the call
+// becomes a no-op when the resource already exists, so a reinstall (or
+// any reapply) can never mutate it. This protects against value drift
+// (e.g. the encryption-key being clobbered with an empty string) and
+// spec drift (e.g. a LoadBalancer Service being demoted to NodePort
+// because cliArgs defaults didn't match the original install).
 func (cpi *ControlPlaneInstaller) CreateOrUpdateKubeResource(
 	resource *unstructured.Unstructured,
 	kubeClient dynamic.Interface,
 	mapper *meta.RESTMapper,
 ) error {
+	// stamp the installer-managed label so reinstall and similar
+	// label-scoped operations can find every resource we create
+	setManagedByLabel(resource)
+
+	if isPersistent(resource) {
+		group, version := splitAPIVersion(resource.GetAPIVersion())
+		if existing, _ := kube.GetResource(
+			group, version, resource.GetKind(),
+			resource.GetNamespace(), resource.GetName(),
+			kubeClient, *mapper,
+		); existing != nil {
+			return nil
+		}
+	}
+
 	if cpi.Opts.CreateOrUpdateKubeResources {
 		if _, err := kube.CreateOrUpdateResource(resource, kubeClient, *mapper); err != nil {
 			return fmt.Errorf("failed to create/update resource: %w", err)
@@ -461,6 +494,50 @@ func (cpi *ControlPlaneInstaller) CreateOrUpdateKubeResource(
 		}
 	}
 	return nil
+}
+
+// isPersistent reports whether the resource carries the persistent
+// opt-out label that gates both the destructive sweep and the
+// in-place reapply.
+func isPersistent(resource *unstructured.Unstructured) bool {
+	return resource.GetLabels()[LabelPersistent] == LabelPersistentValue
+}
+
+// splitAPIVersion splits a kubernetes apiVersion into its group and
+// version parts. Core resources (apiVersion "v1") return an empty
+// group; grouped resources (apiVersion "apps/v1") return both halves.
+func splitAPIVersion(apiVersion string) (group, version string) {
+	if idx := strings.IndexByte(apiVersion, '/'); idx >= 0 {
+		return apiVersion[:idx], apiVersion[idx+1:]
+	}
+	return "", apiVersion
+}
+
+// setManagedByLabel adds the installer's managed-by label to a
+// resource's top-level metadata.labels without touching any other
+// labels already set on the resource.
+func setManagedByLabel(resource *unstructured.Unstructured) {
+	labels := resource.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	if labels[LabelManagedBy] == LabelManagedByValue {
+		return
+	}
+	labels[LabelManagedBy] = LabelManagedByValue
+	resource.SetLabels(labels)
+}
+
+// setPersistent opts a resource out of destructive sweeps. Apply to
+// stateful objects whose loss would break the control plane (database
+// data, certificate authority, external load balancer ip).
+func setPersistent(resource *unstructured.Unstructured) {
+	labels := resource.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[LabelPersistent] = LabelPersistentValue
+	resource.SetLabels(labels)
 }
 
 // UpdateControllerDeployment installs a threeport controller by name.
@@ -499,8 +576,11 @@ func (cpi *ControlPlaneInstaller) InstallThreeportAgent(
 	authConfig *auth.AuthConfig,
 ) error {
 
-	// if auth is enabled on API, generate client cert and key and store in
-	// secrets
+	// if auth is enabled, sign agent client cert. agent-ca and
+	// agent-cert carry the persistent label, so the create-only rule
+	// in CreateOrUpdateKubeResource skips them on reinstall - the
+	// agent's identity stays stable. cert generation above is
+	// redundant work on a reinstall but cheap.
 	if authConfig != nil {
 		agentCertificate, agentPrivateKey, err := auth.GenerateCertificate(
 			authConfig.CAConfig,
@@ -527,6 +607,7 @@ func (cpi *ControlPlaneInstaller) InstallThreeportAgent(
 				},
 			},
 		}
+		setPersistent(agentCa)
 		if err := cpi.CreateOrUpdateKubeResource(agentCa, kubeClient, mapper); err != nil {
 			return fmt.Errorf("failed to create/update API server ca secret for threeport agent: %w", err)
 		}
@@ -1748,6 +1829,9 @@ func (cpi *ControlPlaneInstaller) getSecretVols(name string, mountPath string) (
 }
 
 // getTLSSecret returns a Kubernetes secret for the given certificate and private key.
+// getTLSSecret returns a TLS secret marked persistent. Identities
+// don't need to churn across reinstalls, so every cert the installer
+// stamps out stays put.
 func (cpi *ControlPlaneInstaller) getTLSSecret(name string, certificate string, privateKey string) *unstructured.Unstructured {
 
 	secret := &unstructured.Unstructured{
@@ -1765,7 +1849,7 @@ func (cpi *ControlPlaneInstaller) getTLSSecret(name string, certificate string, 
 			},
 		},
 	}
-
+	setPersistent(secret)
 	return secret
 }
 

--- a/pkg/threeport-installer/v0/dependencies.go
+++ b/pkg/threeport-installer/v0/dependencies.go
@@ -65,7 +65,7 @@ func (cpi *ControlPlaneInstaller) InstallThreeportControlPlaneDependencies(
 			},
 		},
 	}
-
+	setPersistent(encryptionSecret)
 	if err := cpi.CreateOrUpdateKubeResource(encryptionSecret, kubeClient, mapper); err != nil {
 		return fmt.Errorf("failed to create API server secret: %w", err)
 	}
@@ -546,33 +546,39 @@ store_dir: /data
 		},
 	}
 
+	setPersistent(natsStatefulSet)
 	if err := cpi.CreateOrUpdateKubeResource(natsStatefulSet, kubeClient, mapper); err != nil {
 		return fmt.Errorf("failed to create/update API server secret for workload controller: %w", err)
 	}
 
-	// asdf
-	var dbCertsSecret = &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Secret",
-			"metadata": map[string]interface{}{
-				"name":      dbCredsSecretName,
-				"namespace": cpi.Opts.Namespace,
+	// dbCreds is nil on reinstall - constructing the secret would
+	// panic dereferencing dbCreds.AuthConfig. CreateOrUpdate's
+	// persistent-skip catches existing values too late (after
+	// construction), so guard at the call site.
+	if dbCreds != nil {
+		var dbCertsSecret = &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name":      dbCredsSecretName,
+					"namespace": cpi.Opts.Namespace,
+				},
+				"stringData": map[string]interface{}{
+					"ca.crt":               dbCreds.AuthConfig.CAPemEncoded,
+					"node.crt":             dbCreds.NodeCert,
+					"node.key":             dbCreds.NodeKey,
+					"client.root.crt":      dbCreds.RootCert,
+					"client.root.key":      dbCreds.RootKey,
+					"client.threeport.crt": dbCreds.ThreeportCert,
+					"client.threeport.key": dbCreds.ThreeportKey,
+				},
 			},
-			"stringData": map[string]interface{}{
-				"ca.crt":               dbCreds.AuthConfig.CAPemEncoded,
-				"node.crt":             dbCreds.NodeCert,
-				"node.key":             dbCreds.NodeKey,
-				"client.root.crt":      dbCreds.RootCert,
-				"client.root.key":      dbCreds.RootKey,
-				"client.threeport.crt": dbCreds.ThreeportCert,
-				"client.threeport.key": dbCreds.ThreeportKey,
-			},
-		},
-	}
-
-	if err := cpi.CreateOrUpdateKubeResource(dbCertsSecret, kubeClient, mapper); err != nil {
-		return fmt.Errorf("failed to create DB certs secret: %w", err)
+		}
+		setPersistent(dbCertsSecret)
+		if err := cpi.CreateOrUpdateKubeResource(dbCertsSecret, kubeClient, mapper); err != nil {
+			return fmt.Errorf("failed to create DB certs secret: %w", err)
+		}
 	}
 
 	var crdbPDB = &unstructured.Unstructured{
@@ -843,6 +849,7 @@ store_dir: /data
 		},
 	}
 
+	setPersistent(crdbStatefulSet)
 	if err := cpi.CreateOrUpdateKubeResource(crdbStatefulSet, kubeClient, mapper); err != nil {
 		return fmt.Errorf("failed to create/update API server secret for workload controller: %w", err)
 	}
@@ -880,6 +887,7 @@ store_dir: /data
 			},
 		},
 	}
+	setPersistent(apiService)
 	if err := cpi.CreateOrUpdateKubeResource(apiService, kubeClient, mapper); err != nil {
 		return fmt.Errorf("failed to create/update API server service: %w", err)
 	}

--- a/pkg/threeport-installer/v0/labels.go
+++ b/pkg/threeport-installer/v0/labels.go
@@ -1,0 +1,18 @@
+package v0
+
+// Labels stamped on resources the installer creates. They drive
+// label-scoped operations like the dev reinstall sweep.
+const (
+	// LabelManagedBy marks every resource the installer creates so
+	// tooling can list the full set of installer-managed objects with
+	// a single selector.
+	LabelManagedBy      = "app.kubernetes.io/managed-by"
+	LabelManagedByValue = "threeport-installer"
+
+	// LabelPersistent opts a managed resource out of destructive
+	// sweeps. Applied to stateful objects whose loss would break the
+	// control plane (cockroachdb data, certificate authority, external
+	// load balancer ip) and that an in-place spec update can't fix.
+	LabelPersistent      = "threeport.io/persistent"
+	LabelPersistentValue = "true"
+)

--- a/pkg/threeport-installer/v0/reinstall.go
+++ b/pkg/threeport-installer/v0/reinstall.go
@@ -1,0 +1,431 @@
+package v0
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	auth "github.com/threeport/threeport/pkg/auth/v0"
+	kube "github.com/threeport/threeport/pkg/kube/v0"
+	util "github.com/threeport/threeport/pkg/util/v0"
+)
+
+// deploymentGVR is reused by the quiesce and verify phases (which
+// target the rest-api Deployment by name) and by the sweep target
+// set (which lists matching Deployments by label).
+var deploymentGVR = schema.GroupVersionResource{
+	Group:    "apps",
+	Version:  "v1",
+	Resource: "deployments",
+}
+
+// sweepTarget pairs a GVR with whether it's namespace-scoped. Cluster
+// -scoped kinds (ClusterRole, ClusterRoleBinding) skip the .Namespace
+// call on the dynamic client.
+type sweepTarget struct {
+	gvr        schema.GroupVersionResource
+	namespaced bool
+}
+
+// sweepTargets is the closed set of kinds the reinstall sweep walks.
+// Each kind that the installer can create is listed here; resources
+// whose loss is unrecoverable (cascade-delete, data, external state)
+// are deliberately excluded:
+//
+//	customresourcedefinitions - cascade-deletes every cr of that type
+//	namespaces                - cascade-deletes everything in the ns
+//	persistentvolumeclaims    - data loss
+//	statefulsets              - the persistent label protects cockroach
+//	                            and nats specifically; no other
+//	                            installer-managed statefulset exists
+var sweepTargets = []sweepTarget{
+	{deploymentGVR, true},
+	{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}, true},
+	{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}, true},
+	{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}, true},
+	{schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}, true},
+	{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}, true},
+	{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}, true},
+	{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}, false},
+	{schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}, false},
+}
+
+// restApiDeploymentReadyTimeout caps how long Reinstall will wait for
+// the rest-api deployment to roll back to ready after the reapply.
+const restApiDeploymentReadyTimeout = 5 * time.Minute
+
+// Reinstall sweeps every installer-managed stateless deployment in the
+// control plane namespace and then reapplies the install path so the
+// pods come back with fresh images and specs. Designed for dev
+// environments only; production-safe upgrades are a separate flow.
+//
+// The control plane's stateful side - cockroachdb, nats, the
+// certificate authority, the external load balancer - is preserved by
+// the persistent label that those resources carry, so dev users keep
+// their database contents and the api endpoint's public ip across
+// reinstalls.
+//
+// Phases: quiesce -> sweep -> reapply -> verify. The quiesce step
+// scales the rest-api to zero before sweeping so in-cluster
+// reconcilers (the controllers) don't race the sweep by recreating
+// resources we just deleted.
+func (cpi *ControlPlaneInstaller) Reinstall(
+	kubeClient dynamic.Interface,
+	mapper *meta.RESTMapper,
+	authConfig *auth.AuthConfig,
+) error {
+	ns := cpi.Opts.Namespace
+
+	fmt.Println("Info: scaling rest-api to 0 and waiting for pods to terminate")
+	if err := cpi.quiesceForReinstall(kubeClient, ns); err != nil {
+		return fmt.Errorf("failed to quiesce control plane for reinstall: %w", err)
+	}
+
+	fmt.Println("Info: sweeping installer-managed stateless resources across deployments, configmaps, secrets, services, serviceaccounts, roles, rolebindings, clusterroles, clusterrolebindings")
+	deleted, err := cpi.sweepReinstallTargets(kubeClient, ns)
+	if err != nil {
+		return fmt.Errorf("failed to sweep stateless resources: %w", err)
+	}
+	fmt.Printf("Info: swept %d stateless resource(s)\n", deleted)
+
+	// reapply uses CreateOrUpdate so resources that survived the sweep
+	// (configmaps, secrets, rbac, services) are patched in place. set
+	// the flag explicitly in case the installer was constructed for a
+	// fresh install path.
+	cpi.Opts.CreateOrUpdateKubeResources = true
+
+	// dependencies first - encryption-key, nats config, crdb config,
+	// api load balancer service. existence guards on the encryption
+	// secret and db cert secret keep their content intact across this
+	// reapply; the empty arguments below only matter for fresh installs,
+	// which reinstall doesn't run.
+	fmt.Println("Info: reapplying threeport control plane dependencies (nats, crdb, encryption-key, api load balancer)")
+	if err := cpi.InstallThreeportControlPlaneDependencies(kubeClient, mapper, "", nil); err != nil {
+		return fmt.Errorf("failed to reapply control plane dependencies: %w", err)
+	}
+
+	// api server tls assets: pass the cluster-loaded authConfig so
+	// any cert secret that doesn't exist yet (e.g. a brand-new
+	// controller added since the last install) gets signed by the
+	// existing CA. existing cert secrets survive the sweep and are
+	// reused as-is - install functions check existence before
+	// re-issuing.
+	fmt.Println("Info: reapplying threeport api tls assets")
+	if err := cpi.InstallThreeportAPITLS(kubeClient, mapper, authConfig); err != nil {
+		return fmt.Errorf("failed to reapply threeport api tls assets: %w", err)
+	}
+
+	fmt.Println("Info: reapplying threeport api deployment")
+	if err := cpi.UpdateThreeportAPIDeployment(kubeClient, mapper, nil); err != nil {
+		return fmt.Errorf("failed to reapply threeport api deployment: %w", err)
+	}
+
+	fmt.Printf("Info: reapplying %d threeport controller(s)\n", len(cpi.Opts.ControllerList))
+	if err := cpi.InstallThreeportControllers(kubeClient, mapper, authConfig); err != nil {
+		return fmt.Errorf("failed to reapply threeport controllers: %w", err)
+	}
+
+	fmt.Println("Info: reapplying threeport agent")
+	if err := cpi.InstallThreeportAgent(kubeClient, mapper, authConfig); err != nil {
+		return fmt.Errorf("failed to reapply threeport agent: %w", err)
+	}
+
+	fmt.Printf("Info: waiting for rest-api deployment to become ready (timeout %s)\n", restApiDeploymentReadyTimeout)
+	if err := cpi.waitForRestAPIReady(kubeClient, ns, restApiDeploymentReadyTimeout); err != nil {
+		return fmt.Errorf("rest-api did not become ready after reinstall: %w", err)
+	}
+
+	return nil
+}
+
+// quiesceForReinstall scales the rest-api deployment to zero and
+// waits for its pods to fully terminate. Controllers can't drive
+// reconciliation without the api, so this stops them from racing
+// the sweep.
+func (cpi *ControlPlaneInstaller) quiesceForReinstall(
+	kubeClient dynamic.Interface,
+	namespace string,
+) error {
+	name := cpi.Opts.RestApiInfo.ServiceResourceName
+
+	patch := []byte(`{"spec":{"replicas":0}}`)
+	_, err := kubeClient.Resource(deploymentGVR).Namespace(namespace).Patch(
+		context.Background(),
+		name,
+		"application/strategic-merge-patch+json",
+		patch,
+		metav1.PatchOptions{},
+	)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to scale rest-api deployment to zero: %w", err)
+	}
+
+	// poll until the deployment reports zero ready replicas. nothing
+	// downstream needs the pods to be fully gone (they're already not
+	// serving traffic once ready=0), so this stays simple.
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		dep, getErr := kubeClient.Resource(deploymentGVR).Namespace(namespace).Get(
+			context.Background(), name, metav1.GetOptions{},
+		)
+		if errors.IsNotFound(getErr) {
+			return nil
+		}
+		if getErr != nil {
+			return fmt.Errorf("failed to read rest-api deployment status: %w", getErr)
+		}
+		ready, _, _ := unstructuredNestedInt(dep.Object, "status", "readyReplicas")
+		if ready == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("rest-api deployment still has %d ready replica(s) after quiesce timeout", ready)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// sweepReinstallTargets deletes every resource matching the
+// managed-by=threeport-installer label across the closed sweepTargets
+// set, skipping anything marked persistent, then blocks until the
+// deletions actually clear from the api. Returns the count of
+// deletions issued.
+//
+// Uses background cascade so the owner (deployment, clusterrolebinding
+// etc.) leaves the api on first call and the same-named reapply that
+// follows doesn't collide with a still-terminating object. Pods owned
+// by deleted deployments are gc'd asynchronously - the new deployment
+// created right after gets its own replicaset + pods.
+func (cpi *ControlPlaneInstaller) sweepReinstallTargets(
+	kubeClient dynamic.Interface,
+	namespace string,
+) (int, error) {
+	selector := fmt.Sprintf(
+		"%s=%s,%s!=%s",
+		LabelManagedBy, LabelManagedByValue,
+		LabelPersistent, LabelPersistentValue,
+	)
+
+	deletePolicy := metav1.DeletePropagationBackground
+	deleteOpts := metav1.DeleteOptions{PropagationPolicy: &deletePolicy}
+
+	count := 0
+	for _, target := range sweepTargets {
+		// cluster-scoped resources (clusterroles, clusterrolebindings)
+		// skip the namespace call; namespaced resources pin to the
+		// control plane namespace.
+		var ri dynamic.ResourceInterface
+		if target.namespaced {
+			ri = kubeClient.Resource(target.gvr).Namespace(namespace)
+		} else {
+			ri = kubeClient.Resource(target.gvr)
+		}
+
+		list, err := ri.List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			return count, fmt.Errorf(
+				"failed to list %s matching %q: %w",
+				target.gvr.Resource, selector, err,
+			)
+		}
+
+		for _, obj := range list.Items {
+			name := obj.GetName()
+			if err := ri.Delete(context.Background(), name, deleteOpts); err != nil && !errors.IsNotFound(err) {
+				return count, fmt.Errorf(
+					"failed to delete %s/%s: %w",
+					target.gvr.Resource, name, err,
+				)
+			}
+			count++
+		}
+	}
+
+	// k8s Delete is async: the call returns once the deletion is
+	// initiated, not once the object is gone. wait until the label
+	// selector returns empty across every swept kind, so the reapply
+	// step doesn't collide with a still-terminating same-named object.
+	if err := cpi.waitForSweepComplete(kubeClient, namespace, selector); err != nil {
+		return count, fmt.Errorf("sweep deletions did not clear: %w", err)
+	}
+
+	return count, nil
+}
+
+// waitForSweepComplete polls the sweep target set until every kind
+// reports zero label-matching resources, or the deadline elapses.
+// Worst-case shape: many controllers being torn down at once, each
+// with a single replica, all clearing well within the deadline.
+func (cpi *ControlPlaneInstaller) waitForSweepComplete(
+	kubeClient dynamic.Interface,
+	namespace string,
+	selector string,
+) error {
+	deadline := time.Now().Add(2 * time.Minute)
+	for {
+		pending := 0
+		var sample string
+		for _, target := range sweepTargets {
+			var ri dynamic.ResourceInterface
+			if target.namespaced {
+				ri = kubeClient.Resource(target.gvr).Namespace(namespace)
+			} else {
+				ri = kubeClient.Resource(target.gvr)
+			}
+			list, err := ri.List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+			if err != nil {
+				return fmt.Errorf("failed to list %s while waiting for sweep: %w", target.gvr.Resource, err)
+			}
+			if n := len(list.Items); n > 0 {
+				pending += n
+				if sample == "" {
+					sample = fmt.Sprintf("%s/%s", target.gvr.Resource, list.Items[0].GetName())
+				}
+			}
+		}
+		if pending == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%d resource(s) still terminating after 2m (e.g. %s)", pending, sample)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// waitForRestAPIReady polls the rest-api deployment until its ready
+// replicas reach 1, or returns an error at the deadline.
+func (cpi *ControlPlaneInstaller) waitForRestAPIReady(
+	kubeClient dynamic.Interface,
+	namespace string,
+	timeout time.Duration,
+) error {
+	name := cpi.Opts.RestApiInfo.ServiceResourceName
+	deadline := time.Now().Add(timeout)
+	for {
+		dep, err := kubeClient.Resource(deploymentGVR).Namespace(namespace).Get(
+			context.Background(), name, metav1.GetOptions{},
+		)
+		if err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to read rest-api deployment status: %w", err)
+		}
+		if err == nil {
+			ready, _, _ := unstructuredNestedInt(dep.Object, "status", "readyReplicas")
+			if ready >= 1 {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("rest-api deployment not ready after %s", timeout)
+		}
+		time.Sleep(3 * time.Second)
+	}
+}
+
+// LoadAuthConfigFromCluster reads the persistent api-ca Secret and
+// rebuilds an AuthConfig backed by its cert and private key. Reinstall
+// passes the returned config into the install functions so any new
+// controller added since the last install gets a cert signed by the
+// cluster's existing CA, without rotating it. Existing controllers'
+// cert secrets survive the sweep and aren't re-issued.
+func (cpi *ControlPlaneInstaller) LoadAuthConfigFromCluster(
+	kubeClient dynamic.Interface,
+	mapper *meta.RESTMapper,
+) (*auth.AuthConfig, error) {
+	secret, err := kube.GetResource(
+		"", "v1", "Secret",
+		cpi.Opts.Namespace, ThreeportApiCaSecret,
+		kubeClient, *mapper,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load api-ca secret: %w", err)
+	}
+
+	// kube secrets store values base64-encoded under data; decode each
+	// to get the underlying PEM bytes the cert/key parsers expect.
+	caB64, _, err := unstructured.NestedString(secret.Object, "data", "tls.crt")
+	if err != nil || caB64 == "" {
+		return nil, fmt.Errorf("api-ca secret missing data.tls.crt")
+	}
+	keyB64, _, err := unstructured.NestedString(secret.Object, "data", "tls.key")
+	if err != nil || keyB64 == "" {
+		return nil, fmt.Errorf("api-ca secret missing data.tls.key")
+	}
+
+	caPem, err := base64.StdEncoding.DecodeString(caB64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to base64-decode ca cert: %w", err)
+	}
+	keyPem, err := base64.StdEncoding.DecodeString(keyB64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to base64-decode ca key: %w", err)
+	}
+
+	caBlock, _ := pem.Decode(caPem)
+	if caBlock == nil {
+		return nil, fmt.Errorf("ca cert pem block missing")
+	}
+	caCert, err := x509.ParseCertificate(caBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ca cert: %w", err)
+	}
+
+	keyBlock, _ := pem.Decode(keyPem)
+	if keyBlock == nil {
+		return nil, fmt.Errorf("ca key pem block missing")
+	}
+	caKey, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ca key: %w", err)
+	}
+
+	return &auth.AuthConfig{
+		CAConfig:                  caCert,
+		CAPrivateKey:              *caKey,
+		CA:                        caBlock.Bytes,
+		CAPemEncoded:              string(caPem),
+		CABase64Encoded:           util.Base64Encode(string(caPem)),
+		CAPrivateKeyPemEncoded:    string(keyPem),
+		CAPrivateKeyBase64Encoded: util.Base64Encode(string(keyPem)),
+	}, nil
+}
+
+// unstructuredNestedInt fetches a nested int field from an
+// unstructured object's map, returning zero+false when missing. Wraps
+// the json.Number / float64 numeric ambiguity gorm and the kube
+// dynamic client produce.
+func unstructuredNestedInt(obj map[string]interface{}, fields ...string) (int64, bool, error) {
+	cur := obj
+	for i, f := range fields {
+		v, ok := cur[f]
+		if !ok {
+			return 0, false, nil
+		}
+		if i == len(fields)-1 {
+			switch n := v.(type) {
+			case int64:
+				return n, true, nil
+			case float64:
+				return int64(n), true, nil
+			default:
+				return 0, false, fmt.Errorf("field %q has unexpected type %T", f, v)
+			}
+		}
+		next, ok := v.(map[string]interface{})
+		if !ok {
+			return 0, false, nil
+		}
+		cur = next
+	}
+	return 0, false, nil
+}

--- a/pkg/threeport-installer/v0/reinstall.go
+++ b/pkg/threeport-installer/v0/reinstall.go
@@ -120,7 +120,7 @@ func (cpi *ControlPlaneInstaller) Reinstall(
 	// existing CA. existing cert secrets survive the sweep and are
 	// reused as-is - install functions check existence before
 	// re-issuing.
-	fmt.Println("Info: reapplying threeport api tls assets")
+	fmt.Println("Info: ensuring threeport api tls assets")
 	if err := cpi.InstallThreeportAPITLS(kubeClient, mapper, authConfig); err != nil {
 		return fmt.Errorf("failed to reapply threeport api tls assets: %w", err)
 	}

--- a/pkg/threeport-installer/v0/selection.go
+++ b/pkg/threeport-installer/v0/selection.go
@@ -1,0 +1,168 @@
+package v0
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+
+	v0 "github.com/threeport/threeport/pkg/api/v0"
+)
+
+// always-on control plane deployment name prefixes excluded from
+// auto-detection. The rest-api and agent aren't group-scoped and are
+// reapplied on every install path.
+const (
+	restApiStrippedName = "api-server"
+	agentStrippedName   = "agent"
+	deployNamePrefix    = "threeport-"
+)
+
+// SelectControllersByGroup filters allControllers down to those whose
+// component name corresponds to one of the requested sdk-config
+// ApiObjectGroup names. Group names follow sdk-config.yaml exactly
+// (e.g. "kubernetes_workload", "gateway"); the convention
+// "<group>-controller" with underscores converted to dashes maps a
+// group to its component name. An empty groupNames slice returns
+// allControllers unchanged. Unknown group names produce an error
+// listing the valid choices.
+func SelectControllersByGroup(
+	groupNames []string,
+	allControllers []*v0.ControlPlaneComponent,
+) ([]*v0.ControlPlaneComponent, error) {
+	if len(groupNames) == 0 {
+		return allControllers, nil
+	}
+
+	// build name lookup once so each requested group is resolved in
+	// constant time.
+	byName := make(map[string]*v0.ControlPlaneComponent, len(allControllers))
+	for _, controller := range allControllers {
+		byName[controller.Name] = controller
+	}
+
+	selected := make([]*v0.ControlPlaneComponent, 0, len(groupNames))
+	for _, groupName := range groupNames {
+		controllerName := controllerNameForGroup(groupName)
+		controller, ok := byName[controllerName]
+		if !ok {
+			return nil, fmt.Errorf(
+				"unknown api object group %q: valid choices are %s",
+				groupName,
+				strings.Join(validGroupNames(allControllers), ", "),
+			)
+		}
+		selected = append(selected, controller)
+	}
+
+	return selected, nil
+}
+
+// DetectInstalledControllerNames returns the component names of the
+// controller Deployments currently present in the control plane
+// namespace. Uses the installer's managed-by label so it only counts
+// installer-managed deployments. The rest-api and agent deployments
+// are excluded because they aren't controllers and are always
+// reapplied.
+func DetectInstalledControllerNames(
+	kubeClient dynamic.Interface,
+	namespace string,
+) ([]string, error) {
+	selector := fmt.Sprintf("%s=%s", LabelManagedBy, LabelManagedByValue)
+
+	list, err := kubeClient.Resource(deploymentGVR).Namespace(namespace).List(
+		context.Background(),
+		metav1.ListOptions{LabelSelector: selector},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to list installer-managed deployments in namespace %q: %w",
+			namespace, err,
+		)
+	}
+
+	names := make([]string, 0, len(list.Items))
+	for _, item := range list.Items {
+		deployName := item.GetName()
+		// installer deploys controllers as threeport-<name>; strip the
+		// prefix to recover the component name in ControllerList.
+		stripped := strings.TrimPrefix(deployName, deployNamePrefix)
+		if stripped == restApiStrippedName || stripped == agentStrippedName {
+			continue
+		}
+		names = append(names, stripped)
+	}
+
+	sort.Strings(names)
+	return names, nil
+}
+
+// SelectControllersForReinstall picks the controller subset for a
+// reinstall. When explicitGroups is non-empty, it defers to
+// SelectControllersByGroup. Otherwise it auto-detects from the
+// cluster's installer-managed deployments and filters allControllers
+// to that set. The detected return value reports which path was
+// taken so callers can log it.
+func SelectControllersForReinstall(
+	kubeClient dynamic.Interface,
+	namespace string,
+	explicitGroups []string,
+	allControllers []*v0.ControlPlaneComponent,
+) ([]*v0.ControlPlaneComponent, []string, bool, error) {
+	if len(explicitGroups) > 0 {
+		selected, err := SelectControllersByGroup(explicitGroups, allControllers)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		names := make([]string, 0, len(selected))
+		for _, controller := range selected {
+			names = append(names, controller.Name)
+		}
+		return selected, names, false, nil
+	}
+
+	detectedNames, err := DetectInstalledControllerNames(kubeClient, namespace)
+	if err != nil {
+		return nil, nil, true, fmt.Errorf("failed to detect installed controllers: %w", err)
+	}
+
+	wanted := make(map[string]struct{}, len(detectedNames))
+	for _, name := range detectedNames {
+		wanted[name] = struct{}{}
+	}
+
+	selected := make([]*v0.ControlPlaneComponent, 0, len(detectedNames))
+	selectedNames := make([]string, 0, len(detectedNames))
+	for _, controller := range allControllers {
+		if _, ok := wanted[controller.Name]; ok {
+			selected = append(selected, controller)
+			selectedNames = append(selectedNames, controller.Name)
+		}
+	}
+
+	return selected, selectedNames, true, nil
+}
+
+// controllerNameForGroup maps an sdk-config ApiObjectGroup name to
+// its controller component name, mirroring the convention in
+// pkg/sdk/v0/gen/generator.go: append "-controller" and convert
+// underscores to dashes.
+func controllerNameForGroup(groupName string) string {
+	return strings.ReplaceAll(fmt.Sprintf("%s-controller", groupName), "_", "-")
+}
+
+// validGroupNames returns the sorted set of group names derivable
+// from the controller list, used to build clear error messages
+// when a caller passes an unknown group.
+func validGroupNames(allControllers []*v0.ControlPlaneComponent) []string {
+	names := make([]string, 0, len(allControllers))
+	for _, controller := range allControllers {
+		stripped := strings.TrimSuffix(controller.Name, "-controller")
+		names = append(names, strings.ReplaceAll(stripped, "-", "_"))
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/threeport-installer/v0/selection_test.go
+++ b/pkg/threeport-installer/v0/selection_test.go
@@ -1,0 +1,124 @@
+package v0
+
+import (
+	"strings"
+	"testing"
+
+	v0 "github.com/threeport/threeport/pkg/api/v0"
+)
+
+// testControllers returns a small representative list of controllers
+// covering single-word, underscored, and dashed group names.
+func testControllers() []*v0.ControlPlaneComponent {
+	return []*v0.ControlPlaneComponent{
+		{Name: "kubernetes-workload-controller"},
+		{Name: "gateway-controller"},
+		{Name: "kubernetes-runtime-controller"},
+		{Name: "aws-controller"},
+	}
+}
+
+// TestSelectControllersByGroup exercises the pure filter helper
+// across the cases callers depend on: empty input passthrough,
+// single and multi group selection, unknown group rejection, and
+// a known group missing from the controller list.
+func TestSelectControllersByGroup(t *testing.T) {
+	allControllers := testControllers()
+
+	tests := []struct {
+		name        string
+		groupNames  []string
+		controllers []*v0.ControlPlaneComponent
+		wantNames   []string
+		wantErrSub  string
+	}{
+		{
+			name:        "empty group names returns all controllers unchanged",
+			groupNames:  nil,
+			controllers: allControllers,
+			wantNames: []string{
+				"kubernetes-workload-controller",
+				"gateway-controller",
+				"kubernetes-runtime-controller",
+				"aws-controller",
+			},
+		},
+		{
+			name:        "single group selects matching controller",
+			groupNames:  []string{"gateway"},
+			controllers: allControllers,
+			wantNames:   []string{"gateway-controller"},
+		},
+		{
+			name:        "underscored group maps to dashed controller name",
+			groupNames:  []string{"kubernetes_workload"},
+			controllers: allControllers,
+			wantNames:   []string{"kubernetes-workload-controller"},
+		},
+		{
+			name:        "multiple groups select matching controllers in order",
+			groupNames:  []string{"kubernetes_workload", "gateway"},
+			controllers: allControllers,
+			wantNames: []string{
+				"kubernetes-workload-controller",
+				"gateway-controller",
+			},
+		},
+		{
+			name:        "unknown group returns error listing valid choices",
+			groupNames:  []string{"bogus_group"},
+			controllers: allControllers,
+			wantErrSub:  "unknown api object group",
+		},
+		{
+			name:       "group with no controller in trimmed list returns error",
+			groupNames: []string{"aws"},
+			controllers: []*v0.ControlPlaneComponent{
+				{Name: "gateway-controller"},
+				{Name: "kubernetes-workload-controller"},
+			},
+			wantErrSub: "unknown api object group \"aws\"",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := SelectControllersByGroup(tc.groupNames, tc.controllers)
+			if tc.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErrSub)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.wantNames) {
+				t.Fatalf("got %d controllers, want %d", len(got), len(tc.wantNames))
+			}
+			for i, controller := range got {
+				if controller.Name != tc.wantNames[i] {
+					t.Errorf("position %d: got %q, want %q", i, controller.Name, tc.wantNames[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSelectControllersByGroupErrorListsValidNames confirms the error
+// path enumerates the inferred group-name set so users can correct
+// a typo without spelunking the source.
+func TestSelectControllersByGroupErrorListsValidNames(t *testing.T) {
+	_, err := SelectControllersByGroup([]string{"bogus"}, testControllers())
+	if err == nil {
+		t.Fatal("expected error for unknown group, got nil")
+	}
+	for _, expected := range []string{"aws", "gateway", "kubernetes_runtime", "kubernetes_workload"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Errorf("error %q missing expected group %q", err.Error(), expected)
+		}
+	}
+}

--- a/pkg/threeport-installer/v0/support_services.go
+++ b/pkg/threeport-installer/v0/support_services.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	SupportServicesNamespace     = "support-services-system"
+	SupportServicesNamespace     = "threeport-support-services"
 	SupportServicesOperatorImage = "ghcr.io/nukleros/support-services-operator:v0.6.0"
 	RBACProxyImage               = "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"
 


### PR DESCRIPTION
Adds an --apis flag to tptctl up, tptdev up, and tptdev reinstall that takes a comma-separated list of sdk-config api names (e.g. kubernetes_workload,gateway,kubernetes_runtime) and limits the install to those apis' controllers plus the rest-api and agent. The headline use case is tptctl up --control-plane-only --apis <list>, which installs threeport on a pre-existing kubernetes cluster with a chosen subset of controllers.

When --apis is omitted, behavior differs by command: tptdev reinstall auto-detects controllers currently deployed in the cluster (via the threeport.io/managed-by label) and re-applies only those; tptctl up and tptdev up default to the full ThreeportControllerList since there is no prior cluster state to detect from on a fresh install. The asymmetry is deliberate.

The selection logic lives in a new pkg/threeport-installer/v0/selection.go with three helpers. SelectControllersByGroup() is the pure filter shared by all three CLI consumers. DetectInstalledControllerNames() lists installer-managed Deployments to derive the reinstall default. SelectControllersForReinstall() ties them together. The pure helper is positioned for a future ControlPlaneInstance reconciler to call with the same semantics, so non-dev installs of threeport pick up the same mechanism without rework.

Stacked on PR #420. Base will retarget to 0.7 after #420 merges.