### PR TITLE
fix: correct certificate org for extension modules

### DIFF
--- a/pkg/sdk/v0/gen/pkg/installer/installer.go
+++ b/pkg/sdk/v0/gen/pkg/installer/installer.go
@@ -284,7 +284,7 @@ GRANT ALL ON DATABASE %[1]s TO threeport;`, moduleDbName)).Op(",").Line(),
 				Id("x509CaCert"),
 				Id("rsaCaKey"),
 				Lit(fmt.Sprintf("%s-threeport-module", moduleNameKebab)),
-				Qual("github.com/threeport/threeport/pkg/api/lib/v0", "CoreApiNamespace"),
+				Lit(sdkConfig.ApiNamespace),
 				Qual("github.com/threeport/threeport/pkg/auth/v0", "OUControlPlane"),
 			),
 			If(Err().Op("!=").Nil()).Block(


### PR DESCRIPTION
Previously, the organization added to the certificate for extension modules was the core API namespace - `threeport.io`. This change updates that to pull the API namespace for the extension module from the sdk config. Note: the `GenInstaller` function only generates code for extension modules, not core Threeport.