### PR TITLE
fix: reject foreign key changes on full replace

### DIFF
--- a/pkg/api/lib/v0/encrypt_hooks.go
+++ b/pkg/api/lib/v0/encrypt_hooks.go
@@ -36,17 +36,11 @@ func encryptedFieldsFor(obj interface{}) []EncryptedField {
 	return p.EncryptedFields()
 }
 
-// ProcessEncryptTaggedFields encrypts fields tagged `encrypt:"true"`.
-// On update gorm fires the hook on Statement.Model (the loaded row);
-// redirect to Statement.Dest so the inbound plaintext is read instead
-// of stale loaded values. Create paths leave Model == Dest.
+// ProcessEncryptTaggedFields encrypts fields tagged `encrypt:"true"`,
+// reading the inbound values being written so it encrypts the caller's
+// plaintext rather than stale loaded values.
 func ProcessEncryptTaggedFields(tx *gorm.DB, obj interface{}) error {
-	target := obj
-	if dest, ok := tx.Statement.Dest.(EncryptedFieldProvider); ok && dest != obj {
-		target = dest
-	}
-
-	fields := encryptedFieldsFor(target)
+	fields := encryptedFieldsFor(IncomingValues(tx, obj))
 	if len(fields) == 0 {
 		return nil
 	}

--- a/pkg/api/lib/v0/object.go
+++ b/pkg/api/lib/v0/object.go
@@ -57,11 +57,12 @@ func NewCleanSession(tx *gorm.DB) *gorm.DB {
 }
 
 // LoadObjFromDB returns a newly-allocated instance of obj's concrete
-// type populated from the database by ID via a fresh session that
-// does not inherit the current statement's clauses. The original obj
-// is not mutated. Used by GORM hooks that need a clean snapshot of
-// the current row: pre-update state when called from before-hooks,
-// post-update state when called from after-hooks.
+// type populated from the database by ID via a fresh session that does
+// not inherit the current statement's clauses. The original obj is not
+// mutated. It is the call-shape-independent way to read committed state:
+// in a before-update hook that is the pre-update row (needed because
+// under a PUT the receiver holds the caller's new values, not the
+// committed ones); in an after-update hook it is the post-update row.
 func LoadObjFromDB(tx *gorm.DB, obj interface{}, id uint) (interface{}, error) {
 	// allocate a new instance of obj's concrete type via reflection;
 	// the caller's obj stays untouched while loaded values land here

--- a/pkg/api/lib/v0/object.go
+++ b/pkg/api/lib/v0/object.go
@@ -56,23 +56,24 @@ func NewCleanSession(tx *gorm.DB) *gorm.DB {
 	return tx.Session(&gorm.Session{NewDB: true})
 }
 
-// LoadUpdatedObjFromDB returns a newly-allocated instance of obj's concrete
-// type populated from the database by ID. The original obj is not
-// mutated. Use this from GORM hooks that need to read post-write field
-// values while keeping the original as a pre-write snapshot.
-func LoadUpdatedObjFromDB(tx *gorm.DB, obj interface{}, id uint) (interface{}, error) {
+// LoadObjFromDB returns a newly-allocated instance of obj's concrete
+// type populated from the database by ID via a fresh session that
+// does not inherit the current statement's clauses. The original obj
+// is not mutated. Used by GORM hooks that need a clean snapshot of
+// the current row: pre-update state when called from before-hooks,
+// post-update state when called from after-hooks.
+func LoadObjFromDB(tx *gorm.DB, obj interface{}, id uint) (interface{}, error) {
 	// allocate a new instance of obj's concrete type via reflection;
 	// the caller's obj stays untouched while loaded values land here
-	updatedObj := reflect.New(reflect.TypeOf(obj).Elem()).Interface()
+	loaded := reflect.New(reflect.TypeOf(obj).Elem()).Interface()
 
-	// read the row by primary key into updatedObj
-	if err := NewCleanSession(tx).First(updatedObj, id).Error; err != nil {
+	if err := NewCleanSession(tx).First(loaded, id).Error; err != nil {
 		return nil, fmt.Errorf(
-			"failed to reload %s/%d from database: %w",
+			"failed to load %s/%d from database: %w",
 			util.ObjectTypeName(obj), id, err,
 		)
 	}
-	return updatedObj, nil
+	return loaded, nil
 }
 
 // ParseQualifiedType splits "<api-namespace>/<version>.<TypeName>" into

--- a/pkg/api/lib/v0/persist_hooks.go
+++ b/pkg/api/lib/v0/persist_hooks.go
@@ -33,18 +33,10 @@ func persistFalseFieldsFor(obj interface{}) []PersistFalseField {
 // ProcessPersistFalseTaggedFields nulls every column for a field tagged
 // `persist:"false"` before the row is written, so the value never
 // reaches the database. The value travels through the notification
-// payload to the controller and is then dropped.
-//
-// On update gorm fires the hook on Statement.Model (the loaded row);
-// redirect to Statement.Dest so the inbound write side is operated on
-// instead of stale loaded values. Create paths leave Model == Dest.
+// payload to the controller and is then dropped. It operates on the
+// inbound values being written, not stale loaded values.
 func ProcessPersistFalseTaggedFields(tx *gorm.DB, obj interface{}) error {
-	target := obj
-	if dest, ok := tx.Statement.Dest.(PersistFalseFieldProvider); ok && dest != obj {
-		target = dest
-	}
-
-	for _, field := range persistFalseFieldsFor(target) {
+	for _, field := range persistFalseFieldsFor(IncomingValues(tx, obj)) {
 		tx.Statement.SetColumn(strcase.ToSnake(field.Name), nil)
 	}
 

--- a/pkg/api/lib/v0/update_hooks.go
+++ b/pkg/api/lib/v0/update_hooks.go
@@ -1,0 +1,36 @@
+package v0
+
+import (
+	"gorm.io/gorm"
+)
+
+// GORM update hooks fire under two call shapes, and the hook receiver
+// means a different thing in each:
+//
+//	PATCH  db.Model(&committed).Updates(&incoming)
+//	       the receiver is the loaded committed row; the caller's values
+//	       are in tx.Statement.Dest.
+//	PUT    db.Save(&incoming)
+//	       Model == Dest, so the receiver IS the caller's values; there
+//	       is no separate committed row in memory.
+//
+// GORM merges the incoming values onto the receiver between the before-
+// and after-update callbacks, so by an after-update hook the receiver
+// already reflects the committed result under both shapes.
+//
+// To stay correct regardless of shape, hooks read through two helpers
+// rather than the receiver directly: IncomingValues for the values being
+// written, and LoadObjFromDB for a fresh read of the committed row.
+
+// IncomingValues returns the values being written by the current update:
+// tx.Statement.Dest when it differs from the receiver (a PATCH, where the
+// receiver is the loaded committed row), otherwise the receiver itself (a
+// PUT or a create, where the receiver already holds the new values). Use
+// in before-hooks that operate on the caller-supplied values regardless
+// of call shape.
+func IncomingValues(tx *gorm.DB, receiver interface{}) interface{} {
+	if dest := tx.Statement.Dest; dest != nil && dest != receiver {
+		return dest
+	}
+	return receiver
+}

--- a/pkg/api/lib/v0/update_hooks.go
+++ b/pkg/api/lib/v0/update_hooks.go
@@ -34,3 +34,11 @@ func IncomingValues(tx *gorm.DB, receiver interface{}) interface{} {
 	}
 	return receiver
 }
+
+// IsFullReplace reports whether the current update is a full replace (a
+// PUT via Save, where Model == Dest) rather than a partial patch (Updates,
+// where they differ). On a full replace a nil field is an explicit clear;
+// on a patch a nil field is absent and left unchanged.
+func IsFullReplace(tx *gorm.DB, receiver interface{}) bool {
+	return tx.Statement.Dest == receiver
+}

--- a/pkg/api/v0/actuator_validate.go
+++ b/pkg/api/v0/actuator_validate.go
@@ -10,6 +10,10 @@ func (p *Profile) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the Profile is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *Profile).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (p *Profile) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -40,6 +44,10 @@ func (t *Tier) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the Tier is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *Tier).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (t *Tier) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/api/v0/attached_object_validate.go
+++ b/pkg/api/v0/attached_object_validate.go
@@ -14,6 +14,10 @@ func (a *AttachedObjectReference) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the AttachedObjectReference is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *AttachedObjectReference).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (a *AttachedObjectReference) beforeUpdate(tx *gorm.DB) error {
 	// Relationship is the lifecycle dial; silently widening or narrowing it
 	// post-create would change blocking behavior of an existing reference

--- a/pkg/api/v0/aws_validate.go
+++ b/pkg/api/v0/aws_validate.go
@@ -74,6 +74,10 @@ func (a *AwsProvider) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the AwsProvider before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *AwsProvider).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (a *AwsProvider) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -89,6 +93,10 @@ func (a *AwsEksKubernetesRuntimeDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the AwsEksKubernetesRuntimeDefinition before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *AwsEksKubernetesRuntimeDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (a *AwsEksKubernetesRuntimeDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -104,6 +112,10 @@ func (a *AwsEksKubernetesRuntimeInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the AwsEksKubernetesRuntimeInstance before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *AwsEksKubernetesRuntimeInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (a *AwsEksKubernetesRuntimeInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/api/v0/control_plane_validate.go
+++ b/pkg/api/v0/control_plane_validate.go
@@ -10,6 +10,10 @@ func (c *ControlPlaneDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the ControlPlaneDefinition is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *ControlPlaneDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (c *ControlPlaneDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -40,6 +44,10 @@ func (c *ControlPlaneInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the ControlPlaneInstance is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *ControlPlaneInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (c *ControlPlaneInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/api/v0/events_validate.go
+++ b/pkg/api/v0/events_validate.go
@@ -32,6 +32,10 @@ func (e *Event) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the Event is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *Event).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (e *Event) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/api/v0/gateway_validate.go
+++ b/pkg/api/v0/gateway_validate.go
@@ -10,6 +10,10 @@ func (d *DomainNameDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the DomainNameDefinition is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *DomainNameDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (d *DomainNameDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -40,6 +44,10 @@ func (d *DomainNameInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the DomainNameInstance is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *DomainNameInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (d *DomainNameInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -70,6 +78,10 @@ func (g *GatewayDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the GatewayDefinition is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *GatewayDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (g *GatewayDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -100,6 +112,10 @@ func (g *GatewayHttpPort) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the GatewayHttpPort is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *GatewayHttpPort).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (g *GatewayHttpPort) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -130,6 +146,10 @@ func (g *GatewayInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the GatewayInstance is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *GatewayInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (g *GatewayInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -160,6 +180,10 @@ func (g *GatewayTcpPort) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the GatewayTcpPort is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *GatewayTcpPort).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (g *GatewayTcpPort) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/api/v0/gcp_validate.go
+++ b/pkg/api/v0/gcp_validate.go
@@ -16,6 +16,10 @@ func (g *GcpProvider) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the GcpProvider before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *GcpProvider).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (g *GcpProvider) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -52,6 +56,10 @@ func (g *GcpGkeKubernetesRuntimeDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the GcpGkeKubernetesRuntimeDefinition before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *GcpGkeKubernetesRuntimeDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (g *GcpGkeKubernetesRuntimeDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -67,6 +75,10 @@ func (g *GcpGkeKubernetesRuntimeInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the GcpGkeKubernetesRuntimeInstance before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *GcpGkeKubernetesRuntimeInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (g *GcpGkeKubernetesRuntimeInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/api/v0/helm_workload_validate.go
+++ b/pkg/api/v0/helm_workload_validate.go
@@ -10,6 +10,10 @@ func (h *HelmWorkloadDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the HelmWorkloadDefinition is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *HelmWorkloadDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (h *HelmWorkloadDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -40,6 +44,10 @@ func (h *HelmWorkloadInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the HelmWorkloadInstance is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *HelmWorkloadInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (h *HelmWorkloadInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/api/v0/kubernetes_runtime_validate.go
+++ b/pkg/api/v0/kubernetes_runtime_validate.go
@@ -59,6 +59,10 @@ func (k *KubernetesRuntimeDefinition) beforeCreate(tx *gorm.DB) error {
 
 // beforeUpdate validates that no immutable fields are being changed
 // before updates are persisted.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *KubernetesRuntimeDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (k *KubernetesRuntimeDefinition) beforeUpdate(tx *gorm.DB) error {
 	// ensure infra provider is not changed
 	if tx.Statement.Changed("InfraProvider") {
@@ -100,6 +104,10 @@ func (k *KubernetesRuntimeInstance) beforeCreate(tx *gorm.DB) error {
 
 // beforeUpdate validates that no immutable fields are being changed
 // before updates are persisted.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *KubernetesRuntimeInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (k *KubernetesRuntimeInstance) beforeUpdate(tx *gorm.DB) error {
 	// ensure runtime location is not changed
 	if tx.Statement.Changed("Location") {

--- a/pkg/api/v0/kubernetes_workload_validate.go
+++ b/pkg/api/v0/kubernetes_workload_validate.go
@@ -10,6 +10,10 @@ func (w *KubernetesWorkloadDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the KubernetesWorkloadDefinition is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *KubernetesWorkloadDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (w *KubernetesWorkloadDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -40,6 +44,10 @@ func (w *KubernetesWorkloadInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the KubernetesWorkloadInstance is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *KubernetesWorkloadInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (w *KubernetesWorkloadInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -70,6 +78,10 @@ func (w *KubernetesWorkloadResourceDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the KubernetesWorkloadResourceDefinition is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *KubernetesWorkloadResourceDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (w *KubernetesWorkloadResourceDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -100,6 +112,10 @@ func (w *KubernetesWorkloadResourceInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the KubernetesWorkloadResourceInstance is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *KubernetesWorkloadResourceInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (w *KubernetesWorkloadResourceInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/api/v0/log_validate.go
+++ b/pkg/api/v0/log_validate.go
@@ -10,6 +10,10 @@ func (l *LogBackend) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the LogBackend is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *LogBackend).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (l *LogBackend) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -40,6 +44,10 @@ func (l *LogStorageDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the LogStorageDefinition is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *LogStorageDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (l *LogStorageDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -70,6 +78,10 @@ func (l *LogStorageInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the LogStorageInstance is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *LogStorageInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (l *LogStorageInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/api/v0/machine_runtime_validate.go
+++ b/pkg/api/v0/machine_runtime_validate.go
@@ -16,6 +16,10 @@ func (m *MachineRuntimeDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the MachineRuntimeDefinition before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *MachineRuntimeDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (m *MachineRuntimeDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -42,6 +46,10 @@ func (m *MachineRuntimeInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the MachineRuntimeInstance before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *MachineRuntimeInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (m *MachineRuntimeInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/api/v0/machine_workload_validate.go
+++ b/pkg/api/v0/machine_workload_validate.go
@@ -46,10 +46,11 @@ func (m *MachineWorkloadDefinition) beforeCreate(tx *gorm.DB) error {
 	return validateEnv(m.Env)
 }
 
-// beforeUpdate validates the MachineWorkloadDefinition before update. On
-// update paths the receiver is the stale loaded row, so redirect to
-// Statement.Dest for the inbound payload. Mirrors the pattern in
-// ProcessEncryptTaggedFields.
+// beforeUpdate validates the MachineWorkloadDefinition before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *MachineWorkloadDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (m *MachineWorkloadDefinition) beforeUpdate(tx *gorm.DB) error {
 	if !tx.Statement.Changed("Env") {
 		return nil
@@ -71,10 +72,11 @@ func (m *MachineWorkloadInstance) beforeCreate(tx *gorm.DB) error {
 	return validateEnv(m.Env)
 }
 
-// beforeUpdate validates the MachineWorkloadInstance before update. On
-// update paths the receiver is the stale loaded row, so redirect to
-// Statement.Dest for the inbound payload. Mirrors the pattern in
-// ProcessEncryptTaggedFields.
+// beforeUpdate validates the MachineWorkloadInstance before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *MachineWorkloadInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (m *MachineWorkloadInstance) beforeUpdate(tx *gorm.DB) error {
 	if !tx.Statement.Changed("Env") {
 		return nil

--- a/pkg/api/v0/module_validate.go
+++ b/pkg/api/v0/module_validate.go
@@ -20,6 +20,10 @@ func (m *ModuleApi) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the ModuleApi before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *ModuleApi).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (m *ModuleApi) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -65,6 +69,10 @@ func (m *ModuleApiRoute) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the ModuleApiRoute before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *ModuleApiRoute).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (m *ModuleApiRoute) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -117,6 +125,10 @@ func (m *ModuleController) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the ModuleController before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *ModuleController).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (m *ModuleController) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -151,6 +163,10 @@ func (m *ModuleObject) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the ModuleObject before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *ModuleObject).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (m *ModuleObject) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/api/v0/observability_validate.go
+++ b/pkg/api/v0/observability_validate.go
@@ -10,6 +10,10 @@ func (l *LoggingDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the LoggingDefinition is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *LoggingDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (l *LoggingDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -40,6 +44,10 @@ func (l *LoggingInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the LoggingInstance is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *LoggingInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (l *LoggingInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -70,6 +78,10 @@ func (m *MetricsDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the MetricsDefinition is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *MetricsDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (m *MetricsDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -100,6 +112,10 @@ func (m *MetricsInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the MetricsInstance is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *MetricsInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (m *MetricsInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -130,6 +146,10 @@ func (o *ObservabilityDashboardDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the ObservabilityDashboardDefinition is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *ObservabilityDashboardDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (o *ObservabilityDashboardDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -160,6 +180,10 @@ func (o *ObservabilityDashboardInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the ObservabilityDashboardInstance is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *ObservabilityDashboardInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (o *ObservabilityDashboardInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -190,6 +214,10 @@ func (o *ObservabilityStackDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the ObservabilityStackDefinition is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *ObservabilityStackDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (o *ObservabilityStackDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -220,6 +248,10 @@ func (o *ObservabilityStackInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate runs before the ObservabilityStackInstance is updated.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *ObservabilityStackInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (o *ObservabilityStackInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/api/v0/oci_validate.go
+++ b/pkg/api/v0/oci_validate.go
@@ -16,6 +16,10 @@ func (o *OciProvider) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the OciProvider before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *OciProvider).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (o *OciProvider) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -49,6 +53,10 @@ func (o *OciOkeKubernetesRuntimeDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the OciOkeKubernetesRuntimeDefinition before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *OciOkeKubernetesRuntimeDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (o *OciOkeKubernetesRuntimeDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -64,6 +72,10 @@ func (o *OciOkeKubernetesRuntimeInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the OciOkeKubernetesRuntimeInstance before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *OciOkeKubernetesRuntimeInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (o *OciOkeKubernetesRuntimeInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/api/v0/relationship_hooks.go
+++ b/pkg/api/v0/relationship_hooks.go
@@ -110,11 +110,11 @@ func processRelationshipTaggedFieldsBeforeUpdate(tx *gorm.DB, obj interface{}) e
 		return nil
 	}
 
-	// load the pre-update row so the FK check compares against the
-	// committed state, not the inbound payload. obj alone reflects the
-	// caller's intent, which doesn't tell us whether each FK was
-	// previously set.
-	preUpdateObj, err := lib.LoadUpdatedObjFromDB(tx, obj, *objID)
+	// Load the pre-update row from the DB. obj's meaning depends on
+	// the GORM call shape: Updates(&patch) hands the loaded row,
+	// Save(&obj) hands the new values. A fresh First() is the only
+	// call-pattern-independent way to get committed pre-update state.
+	preUpdateObj, err := lib.LoadObjFromDB(tx, obj, *objID)
 	if err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ func processRelationshipTaggedFieldsAfterUpdate(tx *gorm.DB, obj interface{}) er
 
 	// reload from the database so the foreign-key values reflect the
 	// just-committed update, not the pre-update snapshot still on obj
-	updatedObj, err := lib.LoadUpdatedObjFromDB(tx, obj, *objID)
+	updatedObj, err := lib.LoadObjFromDB(tx, obj, *objID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/v0/relationship_hooks.go
+++ b/pkg/api/v0/relationship_hooks.go
@@ -110,10 +110,10 @@ func processRelationshipTaggedFieldsBeforeUpdate(tx *gorm.DB, obj interface{}) e
 		return nil
 	}
 
-	// Load the pre-update row from the DB. obj's meaning depends on
-	// the GORM call shape: Updates(&patch) hands the loaded row,
-	// Save(&obj) hands the new values. A fresh First() is the only
-	// call-pattern-independent way to get committed pre-update state.
+	// read committed pre-update FK values. under a PUT the receiver holds
+	// the caller's new values, so load the committed row to learn which
+	// FKs were previously set; tx.Statement.Changed reports which ones the
+	// update changes.
 	preUpdateObj, err := lib.LoadObjFromDB(tx, obj, *objID)
 	if err != nil {
 		return err
@@ -187,8 +187,9 @@ func processRelationshipTaggedFieldsAfterUpdate(tx *gorm.DB, obj interface{}) er
 		)
 	}
 
-	// reload from the database so the foreign-key values reflect the
-	// just-committed update, not the pre-update snapshot still on obj
+	// read committed FK values. the receiver already reflects them (gorm
+	// merges the update before this hook), so the reload only keeps the FK
+	// reads correct regardless of call shape.
 	updatedObj, err := lib.LoadObjFromDB(tx, obj, *objID)
 	if err != nil {
 		return err

--- a/pkg/api/v0/relationship_hooks.go
+++ b/pkg/api/v0/relationship_hooks.go
@@ -110,20 +110,34 @@ func processRelationshipTaggedFieldsBeforeUpdate(tx *gorm.DB, obj interface{}) e
 		return nil
 	}
 
-	// read committed pre-update FK values. under a PUT the receiver holds
-	// the caller's new values, so load the committed row to learn which
-	// FKs were previously set; tx.Statement.Changed reports which ones the
-	// update changes.
+	// read the committed pre-update row and the inbound values being
+	// written. comparing the two directly is the only call-shape-independent
+	// way to tell whether a previously-set FK is changing: under a PUT the
+	// receiver IS the inbound values, so tx.Statement.Changed has no committed
+	// row to diff against and reports nothing changed.
 	preUpdateObj, err := lib.LoadObjFromDB(tx, obj, *objID)
 	if err != nil {
 		return err
 	}
+	incomingByField := make(map[string]*uint)
+	for _, foreignKey := range relationshipTaggedForeignKeysFor(lib.IncomingValues(tx, obj)) {
+		incomingByField[foreignKey.FieldName] = foreignKey.ObjectID
+	}
 
-	// reject any change (set->different OR set->clear) to a relationship
-	// FK that was previously non-nil. the initial clear->set transition
-	// stays allowed; everything after that requires teardown.
+	// reject any change (set->different OR set->clear) to a relationship FK
+	// that was previously non-nil. the initial clear->set transition stays
+	// allowed; everything after that requires teardown. a nil inbound FK is
+	// an explicit clear on a full replace but an absent, unchanged field on
+	// a patch, so only treat it as a clear when replacing.
+	isReplace := lib.IsFullReplace(tx, obj)
 	for _, preUpdateForeignKey := range relationshipTaggedForeignKeysFor(preUpdateObj) {
-		if preUpdateForeignKey.ObjectID != nil && tx.Statement.Changed(string(preUpdateForeignKey.FieldName)) {
+		if preUpdateForeignKey.ObjectID == nil {
+			continue
+		}
+		incomingID := incomingByField[preUpdateForeignKey.FieldName]
+		cleared := incomingID == nil && isReplace
+		changed := incomingID != nil && *incomingID != *preUpdateForeignKey.ObjectID
+		if cleared || changed {
 			return util.NewBadRequestError(fmt.Sprintf(
 				"%s is immutable once set; tear down and recreate the holder to undo this relationship",
 				preUpdateForeignKey.FieldName,

--- a/pkg/api/v0/relationship_hooks_test.go
+++ b/pkg/api/v0/relationship_hooks_test.go
@@ -254,6 +254,66 @@ func TestRelationshipHooks_BeforeUpdate_FKImmutability(t *testing.T) {
 	_ = transition{}
 }
 
+// TestRelationshipHooks_BeforeUpdate_FKImmutability_FullReplace proves the
+// immutability guard fires on a PUT (gorm.Save), where Model == Dest so a
+// stale tx.Statement.Changed cannot see the change. set->other and
+// set->clear are rejected; clear->set and set->same are allowed, and an
+// untagged FK is never guarded.
+func TestRelationshipHooks_BeforeUpdate_FKImmutability_FullReplace(t *testing.T) {
+	cases := []struct {
+		name         string
+		preSet       bool   // RequiresFK set before the replace
+		newTarget    string // "", "same", or "other": the relationship FK in the replace
+		untaggedOnly bool   // change UntaggedFK set->other, leave RequiresFK nil
+		wantRejected bool
+	}{
+		{name: "tagged_clear_to_set", preSet: false, newTarget: "other", wantRejected: false},
+		{name: "tagged_set_to_other", preSet: true, newTarget: "other", wantRejected: true},
+		{name: "tagged_set_to_clear", preSet: true, newTarget: "", wantRejected: true},
+		{name: "tagged_set_to_same", preSet: true, newTarget: "same", wantRejected: false},
+		{name: "untagged_set_to_other", untaggedOnly: true, wantRejected: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := setupRelTestDB(t)
+			t1 := seedHolder(t, db, "target-1")
+			t2 := seedHolder(t, db, "target-2")
+
+			existing := &testHolder{Name: strPtr("orig")}
+			if tc.preSet {
+				existing.RequiresFK = t1.ID
+			}
+			if tc.untaggedOnly {
+				existing.UntaggedFK = t1.ID
+			}
+			require.NoError(t, db.Create(existing).Error)
+
+			// a full replace carries the existing id and every field; a nil
+			// RequiresFK on this payload is an explicit clear, not an omission
+			replacement := &testHolder{ID: existing.ID, Name: strPtr("replaced")}
+			switch tc.newTarget {
+			case "same":
+				replacement.RequiresFK = t1.ID
+			case "other":
+				replacement.RequiresFK = t2.ID
+			}
+			if tc.untaggedOnly {
+				replacement.UntaggedFK = t2.ID
+			}
+
+			err := db.Save(replacement).Error
+
+			if tc.wantRejected {
+				require.Error(t, err, "full-replace %s should be rejected", tc.name)
+				assert.Contains(t, err.Error(), "immutable once set")
+				return
+			}
+			require.NoError(t, err, "full-replace %s should be allowed", tc.name)
+		})
+	}
+}
+
 // runFKMatrix exercises gorm.Updates(struct) transitions for one FK:
 //   - nil -> set:    allowed
 //   - set -> other:  rejected on tagged FKs

--- a/pkg/api/v0/secret_validate.go
+++ b/pkg/api/v0/secret_validate.go
@@ -15,6 +15,10 @@ func (s *SecretDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the SecretDefinition before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *SecretDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (s *SecretDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -30,6 +34,10 @@ func (s *SecretInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the SecretInstance before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *SecretInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (s *SecretInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/api/v0/terraform_validate.go
+++ b/pkg/api/v0/terraform_validate.go
@@ -12,6 +12,10 @@ func (t *TerraformDefinition) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the TerraformDefinition before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *TerraformDefinition).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (t *TerraformDefinition) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }
@@ -27,6 +31,10 @@ func (t *TerraformInstance) beforeCreate(tx *gorm.DB) error {
 }
 
 // beforeUpdate validates the TerraformInstance before update.
+//
+// Receiver is the loaded DB row. The new field values being written
+// are in tx.Statement.Dest (cast to *TerraformInstance).
+// Use tx.Statement.Changed("FieldName") to detect field changes.
 func (t *TerraformInstance) beforeUpdate(tx *gorm.DB) error {
 	return nil
 }

--- a/pkg/sdk/v0/gen/pkg/api/validate.go
+++ b/pkg/sdk/v0/gen/pkg/api/validate.go
@@ -141,6 +141,15 @@ func emitValidateScaffoldIfMissing(
 				"%s runs %s the %s is %s.",
 				h.userName, tense, typeName, h.verb,
 			))
+			if h.gormName == "BeforeUpdate" {
+				f.Comment("")
+				f.Comment("Receiver is the loaded DB row. The new field values being written")
+				f.Comment(fmt.Sprintf(
+					"are in tx.Statement.Dest (cast to *%s).",
+					typeName,
+				))
+				f.Comment(`Use tx.Statement.Changed("FieldName") to detect field changes.`)
+			}
 			f.Func().Params(
 				Id(receiver).Op("*").Id(typeName),
 			).Id(h.userName).Params(


### PR DESCRIPTION
Clarifies how update hooks see object state and fixes a relationship foreign-key immutability hole that the unclear handling masked.

Adds a teaching comment above every `beforeUpdate` extension point in `pkg/api/v0/*_validate.go`, and the SDK generator emits the same block for newly scaffolded types, explaining that the hook receiver is the loaded DB row, the inbound values are in `tx.Statement.Dest`, and `tx.Statement.Changed` detects per-field changes. `lib.LoadUpdatedObjFromDB` is renamed to `lib.LoadObjFromDB` since it returns a clean snapshot of the current row whether called from a before-hook (pre-update) or an after-hook (post-update).

A new `lib.IncomingValues` helper names the values being written for an update: `tx.Statement.Dest` under a PATCH (where the receiver is the loaded committed row) or the receiver itself under a PUT (where `Model == Dest`). The encrypt and persist hooks now read through it instead of each re-deriving the redirect inline, and a single doc block in `pkg/api/lib/v0/update_hooks.go` documents the two GORM call shapes once.

The relationship FK immutability guard in `processRelationshipTaggedFieldsBeforeUpdate` relied on `tx.Statement.Changed`, which compares `Dest` against the model. Under a PUT (`Save`) the model is the inbound object, so `Changed` always reported no change and a previously-set relationship FK could be silently mutated or cleared through the `ReplaceX` endpoints. The guard now compares the committed pre-update values from `lib.LoadObjFromDB` against the inbound values from `lib.IncomingValues` directly, treating a nil inbound FK as an explicit clear only on a full replace (via `lib.IsFullReplace`) and as an absent, unchanged field on a patch. A Save-shape test covers the previously-untested PUT path alongside the existing Updates matrix.
