### PR TITLE
test: cover oci oke lifecycle adapter

### DIFF
--- a/internal/oci/oke_lifecycle_test.go
+++ b/internal/oci/oke_lifecycle_test.go
@@ -1,0 +1,659 @@
+package oci
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	logr "github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+
+	notif "github.com/threeport/threeport/internal/oci/notif"
+	v0 "github.com/threeport/threeport/pkg/api/v0"
+	util "github.com/threeport/threeport/pkg/util/v0"
+)
+
+// Coverage boundaries in this file:
+//
+// The concrete OCI methods on the OKE infra type (connection fetch, cluster
+// OCID lookup, compartment delete) and the compartment listing inside the
+// infra build live behind the real OCI SDK with context.Background() and no
+// timeout. Their success paths and everything after them are
+// integration-only; unit tests here exercise only the LOCAL failure boundary
+// using okeLocalFailConfigProvider() so no test ever opens a socket.
+//
+// Known-unreachable branch, documented rather than tested: the
+// notification-payload error in both publish methods only fires when JSON
+// marshalling of a pointer/string struct fails, which cannot be forced.
+
+// TestOkeGetReconciliation_Success asserts the reconciliation snapshot maps
+// 1:1 from the instance returned by the API.
+func TestOkeGetReconciliation_Success(t *testing.T) {
+	baseTime := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	creationAck := baseTime
+	creationConfirm := baseTime.Add(1 * time.Minute)
+	deletionScheduled := baseTime.Add(2 * time.Minute)
+	deletionAck := baseTime.Add(3 * time.Minute)
+	deletionConfirm := baseTime.Add(4 * time.Minute)
+	inventory := datatypes.JSON([]byte(`{"vcn":"test-vcn-resource"}`))
+
+	tests := []struct {
+		name   string
+		mutate func(inst *v0.OciOkeKubernetesRuntimeInstance)
+		check  func(t *testing.T, snap okeReconciliationSnapshotCheck)
+	}{
+		{
+			name: "AllTimestampsSet",
+			mutate: func(inst *v0.OciOkeKubernetesRuntimeInstance) {
+				inst.CreationAcknowledged = &creationAck
+				inst.CreationConfirmed = &creationConfirm
+				inst.DeletionScheduled = &deletionScheduled
+				inst.DeletionAcknowledged = &deletionAck
+				inst.DeletionConfirmed = &deletionConfirm
+				inst.ResourceInventory = &inventory
+			},
+			check: func(t *testing.T, snap okeReconciliationSnapshotCheck) {
+				assert.Equal(t, &creationAck, snap.creationAcknowledged)
+				assert.Equal(t, &creationConfirm, snap.creationConfirmed)
+				assert.False(t, snap.creationFailed)
+				assert.Equal(t, &deletionScheduled, snap.deletionScheduled)
+				assert.Equal(t, &deletionAck, snap.deletionAcknowledged)
+				assert.Equal(t, &deletionConfirm, snap.deletionConfirmed)
+				require.NotNil(t, snap.resourceInventory)
+				assert.JSONEq(t, string(inventory), string(*snap.resourceInventory))
+			},
+		},
+		{
+			name:   "NoTimestampsSet",
+			mutate: func(inst *v0.OciOkeKubernetesRuntimeInstance) {},
+			check: func(t *testing.T, snap okeReconciliationSnapshotCheck) {
+				assert.Nil(t, snap.creationAcknowledged)
+				assert.Nil(t, snap.creationConfirmed)
+				assert.False(t, snap.creationFailed)
+				assert.Nil(t, snap.deletionScheduled)
+				assert.Nil(t, snap.deletionAcknowledged)
+				assert.Nil(t, snap.deletionConfirmed)
+				assert.Nil(t, snap.resourceInventory)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inst := okeInstance(42, "oke-snapshot")
+			tt.mutate(inst)
+			api := okeNewAPIStub(t)
+			okeServeInstance(t, api, inst)
+			log := logr.Discard()
+			o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+			snap, err := o.GetReconciliation()
+			require.NoError(t, err)
+			tt.check(t, okeReconciliationSnapshotCheck{
+				creationAcknowledged: snap.CreationAcknowledged,
+				creationConfirmed:    snap.CreationConfirmed,
+				creationFailed:       snap.CreationFailed,
+				deletionScheduled:    snap.DeletionScheduled,
+				deletionAcknowledged: snap.DeletionAcknowledged,
+				deletionConfirmed:    snap.DeletionConfirmed,
+				resourceInventory:    snap.ResourceInventory,
+			})
+		})
+	}
+}
+
+// okeReconciliationSnapshotCheck mirrors the snapshot fields so table cases can
+// assert against them without importing the provider package in each case.
+type okeReconciliationSnapshotCheck struct {
+	creationAcknowledged *time.Time
+	creationConfirmed    *time.Time
+	creationFailed       bool
+	deletionScheduled    *time.Time
+	deletionAcknowledged *time.Time
+	deletionConfirmed    *time.Time
+	resourceInventory    *datatypes.JSON
+}
+
+// TestOkeGetReconciliation_CreationFailedNilVsSet asserts a nil
+// CreationFailed defaults to false in the snapshot and a set value
+// propagates.
+func TestOkeGetReconciliation_CreationFailedNilVsSet(t *testing.T) {
+	tests := []struct {
+		name           string
+		creationFailed *bool
+		want           bool
+	}{
+		{"NilDefaultsFalse", nil, false},
+		{"SetTruePropagates", util.Ptr(true), true},
+		{"SetFalsePropagates", util.Ptr(false), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inst := okeInstance(7, "oke-creation-failed")
+			inst.CreationFailed = tt.creationFailed
+			api := okeNewAPIStub(t)
+			okeServeInstance(t, api, inst)
+			log := logr.Discard()
+			o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+			snap, err := o.GetReconciliation()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, snap.CreationFailed)
+		})
+	}
+}
+
+// TestOkeGetReconciliation_APIError asserts the client error is wrapped.
+func TestOkeGetReconciliation_APIError(t *testing.T) {
+	inst := okeInstance(8, "oke-snapshot-error")
+	api := okeNewAPIStub(t)
+	okeServeError(t, api, okeInstancePath(8), http.StatusInternalServerError)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	snap, err := o.GetReconciliation()
+	require.Error(t, err)
+	assert.Nil(t, snap)
+	assert.Contains(t, err.Error(), "failed to get latest OKE instance")
+}
+
+// TestOkeIsCreateComplete covers the nil, empty, and set cluster OCID
+// branches plus the API error wrap.
+func TestOkeIsCreateComplete(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterOCID *string
+		apiError    bool
+		want        bool
+		wantErr     string
+	}{
+		{name: "NoCluster", clusterOCID: nil, want: false},
+		{name: "EmptyCluster", clusterOCID: util.Ptr(""), want: false},
+		{name: "HasCluster", clusterOCID: util.Ptr("test-cluster-ocid"), want: true},
+		{name: "APIError", apiError: true, wantErr: "failed to check OKE cluster creation status"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inst := okeInstance(9, "oke-create-complete")
+			inst.ClusterOCID = tt.clusterOCID
+			api := okeNewAPIStub(t)
+			if tt.apiError {
+				okeServeError(t, api, okeInstancePath(9), http.StatusInternalServerError)
+			} else {
+				okeServeInstance(t, api, inst)
+			}
+			log := logr.Discard()
+			o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+			complete, err := o.IsCreateComplete()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, complete)
+		})
+	}
+}
+
+// TestOkeAckCreation_SetsAckClearsFailed asserts the PATCH body carries a
+// creation acknowledgement and explicitly clears the failed flag.
+func TestOkeAckCreation_SetsAckClearsFailed(t *testing.T) {
+	inst := okeInstance(10, "oke-ack-creation")
+	api := okeNewAPIStub(t)
+	rec := okeServeInstance(t, api, inst)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	require.NoError(t, o.AckCreation())
+
+	bodies := rec.patchBodies()
+	require.Len(t, bodies, 1)
+	assert.Contains(t, bodies[0], `"CreationAcknowledged"`)
+	assert.Contains(t, bodies[0], `"CreationFailed":false`)
+}
+
+// TestOkeAckCreation_UpdateError asserts the update error propagates.
+func TestOkeAckCreation_UpdateError(t *testing.T) {
+	inst := okeInstance(11, "oke-ack-creation-error")
+	api := okeNewAPIStub(t)
+	okeServeError(t, api, okeInstancePath(11), http.StatusInternalServerError)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	err := o.AckCreation()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "call to threeport API returned unexpected response")
+}
+
+// TestOkeRefreshCreationAck_SetsAckOnly asserts the refresh PATCH carries
+// only the acknowledgement, leaving the failed flag untouched.
+func TestOkeRefreshCreationAck_SetsAckOnly(t *testing.T) {
+	inst := okeInstance(12, "oke-refresh-creation-ack")
+	api := okeNewAPIStub(t)
+	rec := okeServeInstance(t, api, inst)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	require.NoError(t, o.RefreshCreationAck())
+
+	bodies := rec.patchBodies()
+	require.Len(t, bodies, 1)
+	assert.Contains(t, bodies[0], `"CreationAcknowledged"`)
+	assert.NotContains(t, bodies[0], `"CreationFailed"`)
+	assert.NotContains(t, bodies[0], `"CreationConfirmed"`)
+}
+
+// TestOkeSetCreationFailed_SetsTrue asserts the PATCH body marks creation
+// failed without touching the acknowledgement.
+func TestOkeSetCreationFailed_SetsTrue(t *testing.T) {
+	inst := okeInstance(13, "oke-set-creation-failed")
+	api := okeNewAPIStub(t)
+	rec := okeServeInstance(t, api, inst)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	require.NoError(t, o.SetCreationFailed())
+
+	bodies := rec.patchBodies()
+	require.Len(t, bodies, 1)
+	assert.Contains(t, bodies[0], `"CreationFailed":true`)
+	assert.NotContains(t, bodies[0], `"CreationAcknowledged"`)
+}
+
+// TestOkeConfirmCreation_SetsReconciledAndConfirmed asserts the PATCH body
+// carries both the confirmation timestamp and Reconciled=true so the
+// resulting update notification does not retrigger reconciliation.
+func TestOkeConfirmCreation_SetsReconciledAndConfirmed(t *testing.T) {
+	inst := okeInstance(14, "oke-confirm-creation")
+	api := okeNewAPIStub(t)
+	rec := okeServeInstance(t, api, inst)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	require.NoError(t, o.ConfirmCreation())
+
+	bodies := rec.patchBodies()
+	require.Len(t, bodies, 1)
+	assert.Contains(t, bodies[0], `"Reconciled":true`)
+	assert.Contains(t, bodies[0], `"CreationConfirmed"`)
+}
+
+// TestOkeAckDeletion_SetsTimestamp asserts the PATCH body carries a deletion
+// acknowledgement.
+func TestOkeAckDeletion_SetsTimestamp(t *testing.T) {
+	inst := okeInstance(15, "oke-ack-deletion")
+	api := okeNewAPIStub(t)
+	rec := okeServeInstance(t, api, inst)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	require.NoError(t, o.AckDeletion())
+
+	bodies := rec.patchBodies()
+	require.Len(t, bodies, 1)
+	assert.Contains(t, bodies[0], `"DeletionAcknowledged"`)
+	assert.NotContains(t, bodies[0], `"DeletionConfirmed"`)
+}
+
+// TestOkeRefreshDeletionAck_SetsTimestamp asserts the refresh PATCH carries
+// only the deletion acknowledgement.
+func TestOkeRefreshDeletionAck_SetsTimestamp(t *testing.T) {
+	inst := okeInstance(16, "oke-refresh-deletion-ack")
+	api := okeNewAPIStub(t)
+	rec := okeServeInstance(t, api, inst)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	require.NoError(t, o.RefreshDeletionAck())
+
+	bodies := rec.patchBodies()
+	require.Len(t, bodies, 1)
+	assert.Contains(t, bodies[0], `"DeletionAcknowledged"`)
+	assert.NotContains(t, bodies[0], `"DeletionConfirmed"`)
+}
+
+// TestOkeConfirmDeletion_SetsTimestamp asserts the PATCH body carries the
+// deletion confirmation.
+func TestOkeConfirmDeletion_SetsTimestamp(t *testing.T) {
+	inst := okeInstance(17, "oke-confirm-deletion")
+	api := okeNewAPIStub(t)
+	rec := okeServeInstance(t, api, inst)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	require.NoError(t, o.ConfirmDeletion())
+
+	bodies := rec.patchBodies()
+	require.Len(t, bodies, 1)
+	assert.Contains(t, bodies[0], `"DeletionConfirmed"`)
+}
+
+// TestOkeSaveState_PersistsInventory asserts the passed state lands in the
+// PATCH body as the resource inventory.
+func TestOkeSaveState_PersistsInventory(t *testing.T) {
+	inst := okeInstance(18, "oke-save-state")
+	api := okeNewAPIStub(t)
+	rec := okeServeInstance(t, api, inst)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	state := datatypes.JSON([]byte(`{"vcn":"test-vcn-ocid"}`))
+	require.NoError(t, o.SaveState(&state))
+
+	bodies := rec.patchBodies()
+	require.Len(t, bodies, 1)
+	assert.Contains(t, bodies[0], `"ResourceInventory"`)
+	assert.Contains(t, bodies[0], `"vcn":"test-vcn-ocid"`)
+}
+
+// TestOkeClearInventory_SetsEmptyObject asserts the PATCH body resets the
+// resource inventory to an empty JSON object, the destroy-complete signal.
+func TestOkeClearInventory_SetsEmptyObject(t *testing.T) {
+	inst := okeInstance(19, "oke-clear-inventory")
+	api := okeNewAPIStub(t)
+	rec := okeServeInstance(t, api, inst)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	require.NoError(t, o.ClearInventory())
+
+	bodies := rec.patchBodies()
+	require.Len(t, bodies, 1)
+	assert.Contains(t, bodies[0], `"ResourceInventory":{}`)
+}
+
+// TestOkeOnCreateConfirmed_GetConnectionError covers the only reachable
+// branch of OnCreateConfirmed(): its first call is GetConnection() on the
+// concrete OKE infra, which needs a real OCI endpoint. The local-fail config
+// provider makes the OCI client constructor reject the credentials before
+// any socket opens. The instance-get, KRI-get, KRI-update, and success
+// branches all sit after GetConnection() and are integration-only. The
+// forbid-all stub proves no API call is issued before the failure.
+func TestOkeOnCreateConfirmed_GetConnectionError(t *testing.T) {
+	inst := okeInstance(20, "oke-create-confirmed")
+	api := okeNewAPIStub(t)
+	okeForbidAPIRequests(t, api)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	err := o.OnCreateConfirmed(okeLocalFailInfra("oke-create-confirmed"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get Kubernetes API connection info")
+}
+
+// TestOkeSaveCreateOutputs_GetClusterOCIDError covers the only reachable
+// branch of SaveCreateOutputs(): its first call is GetClusterOCID() on the
+// concrete OKE infra. The local-fail config provider forces a local client
+// construction failure with zero sockets; the update/success path after it
+// is integration-only. The forbid-all stub proves no PATCH is issued.
+func TestOkeSaveCreateOutputs_GetClusterOCIDError(t *testing.T) {
+	inst := okeInstance(21, "oke-save-outputs")
+	api := okeNewAPIStub(t)
+	okeForbidAPIRequests(t, api)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	state := datatypes.JSON([]byte(`{}`))
+	err := o.SaveCreateOutputs(okeLocalFailInfra("oke-save-outputs"), &state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get OKE cluster OCID")
+}
+
+// TestOkeOnDeleteConfirmed_CompartmentErrorPropagates is the critical
+// delete-path guard: a compartment delete failure means cloud resources are
+// orphaned, so OnDeleteConfirmed() must RETURN the error, never swallow it.
+// The local-fail config provider makes the OCI identity client constructor
+// fail locally (asserted via the inner wrap), so no socket opens and the
+// method returns before the post-compartment cleanup. The cleanup branches
+// (stack-state delete, instance get, KRI update/delete) run only after a
+// successful compartment delete and are integration-only. The forbid-all
+// stub proves no API call is issued.
+func TestOkeOnDeleteConfirmed_CompartmentErrorPropagates(t *testing.T) {
+	inst := okeInstance(22, "oke-delete-confirmed")
+	api := okeNewAPIStub(t)
+	okeForbidAPIRequests(t, api)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	err := o.OnDeleteConfirmed(okeLocalFailInfra("oke-delete-confirmed"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete OCI compartment")
+	assert.Contains(t, err.Error(), "failed to create identity client")
+}
+
+// TestOkePublishCreateNotification_Success asserts the create subject and a
+// payload built from the in-memory instance; no API call is involved. The
+// payload-error branch is known-unreachable: marshalling a pointer/string
+// struct cannot fail.
+func TestOkePublishCreateNotification_Success(t *testing.T) {
+	inst := okeInstance(30, "oke-notify-create")
+	js := &okeFakeJetStream{}
+	api := okeNewAPIStub(t)
+	okeForbidAPIRequests(t, api)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", js), inst, &log)
+
+	require.NoError(t, o.PublishCreateNotification())
+
+	subjects, payloads := js.published()
+	require.Equal(t, []string{notif.OciOkeKubernetesRuntimeInstanceCreateSubject}, subjects)
+	require.Len(t, payloads, 1)
+	assert.Contains(t, string(payloads[0]), `"Operation":"Created"`)
+	assert.Contains(t, string(payloads[0]), `"oke-notify-create"`)
+}
+
+// TestOkePublishCreateNotification_PublishError asserts the publish error
+// wrap.
+func TestOkePublishCreateNotification_PublishError(t *testing.T) {
+	inst := okeInstance(31, "oke-notify-create-error")
+	js := &okeFakeJetStream{publishErr: errors.New("nats unavailable")}
+	api := okeNewAPIStub(t)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", js), inst, &log)
+
+	err := o.PublishCreateNotification()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to publish create notification")
+}
+
+// TestOkePublishDeleteNotification_Success asserts the delete subject and
+// payload operation.
+func TestOkePublishDeleteNotification_Success(t *testing.T) {
+	inst := okeInstance(32, "oke-notify-delete")
+	js := &okeFakeJetStream{}
+	api := okeNewAPIStub(t)
+	okeForbidAPIRequests(t, api)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", js), inst, &log)
+
+	require.NoError(t, o.PublishDeleteNotification())
+
+	subjects, payloads := js.published()
+	require.Equal(t, []string{notif.OciOkeKubernetesRuntimeInstanceDeleteSubject}, subjects)
+	require.Len(t, payloads, 1)
+	assert.Contains(t, string(payloads[0]), `"Operation":"Deleted"`)
+	assert.Contains(t, string(payloads[0]), `"oke-notify-delete"`)
+}
+
+// TestOkePublishDeleteNotification_PublishError asserts the publish error
+// wrap.
+func TestOkePublishDeleteNotification_PublishError(t *testing.T) {
+	inst := okeInstance(33, "oke-notify-delete-error")
+	js := &okeFakeJetStream{publishErr: errors.New("nats unavailable")}
+	api := okeNewAPIStub(t)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", js), inst, &log)
+
+	err := o.PublishDeleteNotification()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to publish delete notification")
+}
+
+// TestBuildOkeInfra_ProviderGetError asserts the provider fetch error wrap.
+func TestBuildOkeInfra_ProviderGetError(t *testing.T) {
+	inst := okeInstance(40, "oke-build-provider-error")
+	inst.OciProviderID = util.Ptr(uint(400))
+	api := okeNewAPIStub(t)
+	okeServeError(t, api, fmt.Sprintf("%s/%d", v0.PathOciProviders, 400), http.StatusInternalServerError)
+	log := logr.Discard()
+
+	infra, err := buildOkeInfra(okeReconciler(api, "", nil), inst, okeDefinition(41), &log)
+	require.Error(t, err)
+	assert.Nil(t, infra)
+	assert.Contains(t, err.Error(), "failed to retrieve OCI provider by ID")
+}
+
+// TestBuildOkeInfra_DecryptError asserts the private key decrypt error wrap
+// when the stored key is not valid ciphertext for the reconciler's key.
+func TestBuildOkeInfra_DecryptError(t *testing.T) {
+	key := okeNewEncryptionKey(t)
+	inst := okeInstance(42, "oke-build-decrypt-error")
+	inst.OciProviderID = util.Ptr(uint(402))
+	prov := okeProvider(t, 402, key)
+	prov.PrivateKey = util.Ptr("not-valid-ciphertext")
+	api := okeNewAPIStub(t)
+	okeServeGet(t, api, fmt.Sprintf("%s/%d", v0.PathOciProviders, 402), *prov)
+	log := logr.Discard()
+
+	infra, err := buildOkeInfra(okeReconciler(api, key, nil), inst, okeDefinition(43), &log)
+	require.Error(t, err)
+	assert.Nil(t, infra)
+	assert.Contains(t, err.Error(), "failed to decrypt OCI provider private key")
+}
+
+// TestBuildOkeInfra_RegionFallback drives all three region-selection
+// variants through the provider-fetch, decrypt, and region-resolution
+// phases. The selected region is NOT observable from a unit test: the
+// provider's private key decrypts to a non-PEM plaintext, so the OCI
+// identity client constructor rejects the config LOCALLY before any socket
+// opens, and the constructed infra carrying the resolved region is
+// discarded. Asserting the error is the identity-client wrap, not an
+// earlier provider/decrypt wrap, proves each variant got through region
+// resolution without a nil-deref panic. The compartment listing and its
+// fallback branch after client construction need a real OCI call and are
+// integration-only.
+func TestBuildOkeInfra_RegionFallback(t *testing.T) {
+	tests := []struct {
+		name   string
+		region *string
+	}{
+		{"NilRegionUsesProviderDefault", nil},
+		{"EmptyRegionUsesProviderDefault", util.Ptr("")},
+		{"InstanceRegionUsed", util.Ptr("us-ashburn-1")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := okeNewEncryptionKey(t)
+			inst := okeInstance(44, "oke-build-region")
+			inst.OciProviderID = util.Ptr(uint(404))
+			inst.Region = tt.region
+			api := okeNewAPIStub(t)
+			okeServeGet(t, api, fmt.Sprintf("%s/%d", v0.PathOciProviders, 404), *okeProvider(t, 404, key))
+			log := logr.Discard()
+
+			infra, err := buildOkeInfra(okeReconciler(api, key, nil), inst, okeDefinition(45), &log)
+			require.Error(t, err)
+			assert.Nil(t, infra)
+			assert.Contains(t, err.Error(), "failed to create identity client")
+		})
+	}
+}
+
+// TestBuildOkeInfra_DefinitionGetError drives the definition fetch error
+// through BuildInfra(), which resolves the definition before delegating to
+// the infra build.
+func TestBuildOkeInfra_DefinitionGetError(t *testing.T) {
+	inst := okeInstance(46, "oke-build-definition-error")
+	inst.OciOkeKubernetesRuntimeDefinitionID = util.Ptr(uint(460))
+	api := okeNewAPIStub(t)
+	okeServeInstance(t, api, inst)
+	okeServeError(t, api, fmt.Sprintf("%s/%d", v0.PathOciOkeKubernetesRuntimeDefinitions, 460), http.StatusInternalServerError)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	infra, err := o.BuildInfra()
+	require.Error(t, err)
+	assert.Nil(t, infra)
+	assert.Contains(t, err.Error(), "failed to get OKE definition")
+}
+
+// TestOkeBuildInfra_InstanceGetError asserts the instance fetch error wrap
+// on BuildInfra's first call.
+func TestOkeBuildInfra_InstanceGetError(t *testing.T) {
+	inst := okeInstance(47, "oke-build-instance-error")
+	api := okeNewAPIStub(t)
+	okeServeError(t, api, okeInstancePath(47), http.StatusInternalServerError)
+	log := logr.Discard()
+	o := newOkeLifecycleProvider(okeReconciler(api, "", nil), inst, &log)
+
+	infra, err := o.BuildInfra()
+	require.Error(t, err)
+	assert.Nil(t, infra)
+	assert.Contains(t, err.Error(), "failed to get OKE instance for infra build")
+}
+
+// TestOkeEntryUpdated_NoOp asserts the update entry point is a no-op.
+func TestOkeEntryUpdated_NoOp(t *testing.T) {
+	inst := okeInstance(50, "oke-entry-updated")
+	api := okeNewAPIStub(t)
+	okeForbidAPIRequests(t, api)
+	log := logr.Discard()
+
+	delay, err := v0OciOkeKubernetesRuntimeInstanceUpdated(okeReconciler(api, "", nil), inst, &log)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), delay)
+}
+
+// TestOkeEntryCreated_DelegatesToHandleInfraCreate proves the create entry
+// point wires the lifecycle provider into the shared state machine. The
+// served instance is already creation-confirmed, so the state machine
+// short-circuits right after the reconciliation fetch: no goroutine
+// launches and no OCI code runs.
+func TestOkeEntryCreated_DelegatesToHandleInfraCreate(t *testing.T) {
+	inst := okeInstance(51, "oke-entry-created")
+	confirmed := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	inst.CreationConfirmed = &confirmed
+	api := okeNewAPIStub(t)
+	okeServeInstance(t, api, inst)
+	log := logr.Discard()
+
+	delay, err := v0OciOkeKubernetesRuntimeInstanceCreated(okeReconciler(api, "", nil), inst, &log)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), delay)
+}
+
+// TestOkeEntryDeleted_NotScheduledError proves the delete entry point
+// wiring via the OCI-free guard: a delete notification for an instance with
+// no deletion scheduled is an error.
+func TestOkeEntryDeleted_NotScheduledError(t *testing.T) {
+	inst := okeInstance(52, "oke-entry-deleted")
+	api := okeNewAPIStub(t)
+	okeServeInstance(t, api, inst)
+	log := logr.Discard()
+
+	_, err := v0OciOkeKubernetesRuntimeInstanceDeleted(okeReconciler(api, "", nil), inst, &log)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deletion notification received but not scheduled")
+}
+
+// TestOkeEntryDeleted_AlreadyConfirmed asserts a deletion-confirmed instance
+// short-circuits the delete state machine with no OCI work.
+func TestOkeEntryDeleted_AlreadyConfirmed(t *testing.T) {
+	inst := okeInstance(53, "oke-entry-deleted-confirmed")
+	scheduled := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	confirmed := scheduled.Add(time.Minute)
+	inst.DeletionScheduled = &scheduled
+	inst.DeletionConfirmed = &confirmed
+	api := okeNewAPIStub(t)
+	okeServeInstance(t, api, inst)
+	log := logr.Discard()
+
+	delay, err := v0OciOkeKubernetesRuntimeInstanceDeleted(okeReconciler(api, "", nil), inst, &log)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), delay)
+}

--- a/internal/oci/oke_testsupport_test.go
+++ b/internal/oci/oke_testsupport_test.go
@@ -1,0 +1,239 @@
+package oci
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/threeport/threeport/internal/machinetest"
+	"github.com/threeport/threeport/internal/provider"
+	apiserver_lib "github.com/threeport/threeport/pkg/api-server/lib/v0"
+	v0 "github.com/threeport/threeport/pkg/api/v0"
+	controller "github.com/threeport/threeport/pkg/controller/v0"
+	encryption "github.com/threeport/threeport/pkg/encryption/v0"
+	util "github.com/threeport/threeport/pkg/util/v0"
+)
+
+// All package-level test identifiers in this file are prefixed oke/oci so a
+// sibling worktree can later add _test.go files to this package without
+// collisions. No TestMain is defined here for the same reason.
+
+// okeNewAPIStub returns the shared machinetest API stub under an
+// oke-prefixed name.
+func okeNewAPIStub(t *testing.T) *machinetest.APIStub {
+	t.Helper()
+	return machinetest.NewAPIStub(t)
+}
+
+// okeNewEncryptionKey returns a fresh AES-256 key under an oke-prefixed name.
+func okeNewEncryptionKey(t *testing.T) string {
+	t.Helper()
+	return machinetest.NewEncryptionKey(t)
+}
+
+// okeWriteResponse writes data in the response envelope the threeport client
+// helpers expect.
+func okeWriteResponse(t *testing.T, w http.ResponseWriter, status int, data []apiserver_lib.Object) {
+	t.Helper()
+	machinetest.WriteResponse(t, w, status, data)
+}
+
+// okeFakeJetStream satisfies nats.JetStreamContext by embedding the
+// interface and overriding only Publish(). Any other method panics on the
+// nil embedded interface, which is desirable: the lifecycle methods under
+// test must never touch JetStream beyond publishing.
+type okeFakeJetStream struct {
+	nats.JetStreamContext
+
+	mu         sync.Mutex
+	subjects   []string
+	payloads   [][]byte
+	publishErr error
+}
+
+func (f *okeFakeJetStream) Publish(subj string, data []byte, opts ...nats.PubOpt) (*nats.PubAck, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.publishErr != nil {
+		return nil, f.publishErr
+	}
+	f.subjects = append(f.subjects, subj)
+	f.payloads = append(f.payloads, append([]byte(nil), data...))
+	return &nats.PubAck{}, nil
+}
+
+// published returns copies of the recorded subjects and payloads.
+func (f *okeFakeJetStream) published() ([]string, [][]byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	subjects := append([]string(nil), f.subjects...)
+	payloads := append([][]byte(nil), f.payloads...)
+	return subjects, payloads
+}
+
+// okeReconciler builds a controller.Reconciler pointed at the API stub.
+func okeReconciler(api *machinetest.APIStub, key string, js nats.JetStreamContext) *controller.Reconciler {
+	return &controller.Reconciler{
+		APIClient:        api.Client,
+		APIServer:        api.Addr,
+		EncryptionKey:    key,
+		JetStreamContext: js,
+	}
+}
+
+// okeInstance builds an OKE runtime instance with ID and Name set. Both are
+// dereferenced by the entry points and the lifecycle constructor, so every
+// fixture must carry them. Tests set additional fields directly.
+func okeInstance(id uint, name string) *v0.OciOkeKubernetesRuntimeInstance {
+	return &v0.OciOkeKubernetesRuntimeInstance{
+		Common:   v0.Common{ID: util.Ptr(id)},
+		Instance: v0.Instance{Name: util.Ptr(name)},
+	}
+}
+
+// okeInstancePath returns the API path for an OKE runtime instance ID.
+func okeInstancePath(id uint) string {
+	return fmt.Sprintf("%s/%d", v0.PathOciOkeKubernetesRuntimeInstances, id)
+}
+
+// okeRequestRecorder captures PATCH bodies sent to the API stub so tests can
+// assert which reconciliation fields a lifecycle method persisted.
+type okeRequestRecorder struct {
+	mu     sync.Mutex
+	bodies [][]byte
+}
+
+// patchBodies returns the recorded PATCH bodies as strings.
+func (rec *okeRequestRecorder) patchBodies() []string {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	bodies := make([]string, len(rec.bodies))
+	for i, b := range rec.bodies {
+		bodies[i] = string(b)
+	}
+	return bodies
+}
+
+// okeServeInstance registers a handler at the instance's path that serves
+// the instance on GET and echoes the patched object on PATCH, recording each
+// PATCH body for assertion.
+func okeServeInstance(t *testing.T, api *machinetest.APIStub, inst *v0.OciOkeKubernetesRuntimeInstance) *okeRequestRecorder {
+	t.Helper()
+	rec := &okeRequestRecorder{}
+	api.Mux.HandleFunc(okeInstancePath(*inst.ID), func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			okeWriteResponse(t, w, http.StatusOK, []apiserver_lib.Object{*inst})
+		case http.MethodPatch:
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			rec.mu.Lock()
+			rec.bodies = append(rec.bodies, body)
+			rec.mu.Unlock()
+			var updated v0.OciOkeKubernetesRuntimeInstance
+			require.NoError(t, json.Unmarshal(body, &updated))
+			updated.ID = inst.ID
+			okeWriteResponse(t, w, http.StatusOK, []apiserver_lib.Object{updated})
+		default:
+			t.Errorf("unexpected method %s on %s", r.Method, r.URL.Path)
+		}
+	})
+	return rec
+}
+
+// okeServeGet registers a GET-only handler serving obj at path.
+func okeServeGet(t *testing.T, api *machinetest.APIStub, path string, obj apiserver_lib.Object) {
+	t.Helper()
+	api.Mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		okeWriteResponse(t, w, http.StatusOK, []apiserver_lib.Object{obj})
+	})
+}
+
+// okeServeError registers a handler returning the given status with an empty
+// response envelope so the client error path parses cleanly.
+func okeServeError(t *testing.T, api *machinetest.APIStub, path string, status int) {
+	t.Helper()
+	api.Mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		okeWriteResponse(t, w, status, nil)
+	})
+}
+
+// okeForbidAPIRequests registers a catch-all handler that fails the test if
+// any API request arrives. OCI-boundary tests use it to prove the method
+// under test returns at the local failure before issuing any API call.
+func okeForbidAPIRequests(t *testing.T, api *machinetest.APIStub) {
+	t.Helper()
+	api.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected API request: %s %s", r.Method, r.URL.Path)
+		okeWriteResponse(t, w, http.StatusInternalServerError, nil)
+	})
+}
+
+// okeLocalFailConfigProvider returns a config provider that every OCI client
+// constructor rejects LOCALLY: the empty region fails the SDK's
+// configuration-validity region check and the non-PEM key fails its PEM
+// decode check, both before any socket is opened. Tenancy, user, and
+// fingerprint are non-empty dummies so the forced failure lands
+// deterministically on the region/PEM checks rather than an earlier
+// empty-field error. Every test that touches a concrete OCI method MUST use
+// this provider: the SDK calls run with context.Background() and no timeout,
+// so a syntactically valid config would dial the real OCI endpoint and hang.
+func okeLocalFailConfigProvider() common.ConfigurationProvider {
+	return common.NewRawConfigurationProvider(
+		"dummy-tenancy",
+		"dummy-user",
+		"",
+		"dummy-fingerprint",
+		"not-a-pem-key",
+		nil,
+	)
+}
+
+// okeLocalFailInfra builds an OKE infra whose concrete OCI methods all fail
+// locally at client construction, guaranteeing no network dial.
+func okeLocalFailInfra(name string) *provider.KubernetesRuntimeInfraOKE {
+	return &provider.KubernetesRuntimeInfraOKE{
+		PulumiWorkspace: provider.PulumiWorkspace{RuntimeInstanceName: name},
+		Region:          "us-ashburn-1",
+		ConfigProvider:  okeLocalFailConfigProvider(),
+	}
+}
+
+// okeProvider builds an OCI provider record whose PrivateKey decrypts
+// successfully but yields a non-PEM plaintext, so the infra build passes the
+// decrypt phase and then fails LOCALLY at OCI identity client construction
+// without reaching the network.
+func okeProvider(t *testing.T, id uint, encryptionKey string) *v0.OciProvider {
+	t.Helper()
+	encryptedKey, err := encryption.Encrypt(encryptionKey, "not-a-pem-key")
+	require.NoError(t, err)
+	return &v0.OciProvider{
+		Common:          v0.Common{ID: util.Ptr(id)},
+		Name:            util.Ptr("test-oci-provider"),
+		UserOCID:        util.Ptr("dummy-user"),
+		TenancyOCID:     util.Ptr("dummy-tenancy"),
+		CompartmentOCID: util.Ptr("dummy-compartment"),
+		DefaultRegion:   util.Ptr("us-phoenix-1"),
+		KeyFingerprint:  util.Ptr("dummy-fingerprint"),
+		PrivateKey:      util.Ptr(encryptedKey),
+	}
+}
+
+// okeDefinition builds an OKE definition carrying the worker-node fields the
+// infra build dereferences.
+func okeDefinition(id uint) *v0.OciOkeKubernetesRuntimeDefinition {
+	return &v0.OciOkeKubernetesRuntimeDefinition{
+		Common:                 v0.Common{ID: util.Ptr(id)},
+		Definition:             v0.Definition{Name: util.Ptr("test-oke-definition")},
+		WorkerNodeShape:        util.Ptr("VM.Standard.E4.Flex"),
+		WorkerNodeInitialCount: util.Ptr(int32(2)),
+	}
+}


### PR DESCRIPTION
Adds unit tests for the OCI OKE lifecycle adapter in package oci, covering the InfraLifecycleProvider implementation on okeLifecycle, buildOkeInfra, and the two reconciler entry points. The 17 lifecycle methods are tested to their reachable boundary against an in-process httptest API stub and a fake JetStream context: the 14 API and NATS methods end to end, and the three that take an InfraProvider (OnCreateConfirmed(), SaveCreateOutputs(), OnDeleteConfirmed()) up to the local-failure boundary of their concrete OCI calls, since driving them further needs a real OCI network call and is left integration-only. The compartment-delete-error guard in OnDeleteConfirmed() is pinned by test so a future refactor cannot silently swallow it. Both notification publishers assert subject and payload.

No production code changes. Every config provider used in a test fails locally before any socket opens, so the suite is deterministic under go test -race -count=5 with no network I/O. mage build:tptctl and mage build:allBinsDev are green.

Two follow-ups belong to the shared internal/provider package and are out of scope here: a validity and overlap test for the unexported OKE CIDR constants, and bounding the OCI SDK calls that currently use context.Background() with no timeout. Both are noted for the core lifecycle test PR.