### PR TITLE
test: harden infra provider lifecycle with tests and seams

### DIFF
--- a/internal/provider/execute_semaphore_test.go
+++ b/internal/provider/execute_semaphore_test.go
@@ -1,0 +1,419 @@
+package provider
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+// compile-time interface satisfaction check for the order recorder.
+var _ RefreshableProvider = (*orderRecordingInfra)(nil)
+
+// configureSemaphoreTest installs a lifecycle config with the given
+// semaphore capacity and fast persist retries, registers config
+// restoration, and registers a drain that runs before restoration so no
+// launch goroutine outlives the test's semaphore channel.
+func configureSemaphoreTest(t *testing.T, capacity int) {
+	t.Helper()
+	restore := setLifecycleConfig(LifecycleConfig{
+		StaleAckThreshold: 240 * time.Second,
+		RefreshInterval:   time.Hour,
+		SemaphoreCapacity: capacity,
+		PersistRetries:    3,
+		PersistRetryDelay: time.Millisecond,
+	})
+	t.Cleanup(restore)
+	t.Cleanup(func() { waitForSemaphoreDrain(t) })
+}
+
+// waitForSemaphoreDrain polls until no infra operations are in flight and
+// every semaphore slot has been released. The slot release is the last
+// action of a launch goroutine, so an empty semaphore plus a zero
+// in-flight count guarantees all launched goroutines have fully exited.
+func waitForSemaphoreDrain(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if inFlightCount() == 0 && len(infraSemaphore) == 0 {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Errorf(
+		"lifecycle goroutines did not drain: inFlight=%d, heldSlots=%d",
+		inFlightCount(), len(infraSemaphore),
+	)
+}
+
+// orderRecordingInfra wraps fakeRefreshableInfra and records the global
+// order of restore, refresh, and deploy calls so tests can assert the
+// sequencing inside executeInfraCreate.
+type orderRecordingInfra struct {
+	*fakeRefreshableInfra
+
+	omu   sync.Mutex
+	order []string
+}
+
+// newOrderRecordingInfra returns an order recorder over a fresh
+// refreshable infra fake.
+func newOrderRecordingInfra() *orderRecordingInfra {
+	return &orderRecordingInfra{fakeRefreshableInfra: newFakeRefreshableInfra()}
+}
+
+// record appends a call name to the recorded order.
+func (o *orderRecordingInfra) record(name string) {
+	o.omu.Lock()
+	defer o.omu.Unlock()
+	o.order = append(o.order, name)
+}
+
+// callOrder returns a copy of the recorded call order.
+func (o *orderRecordingInfra) callOrder() []string {
+	o.omu.Lock()
+	defer o.omu.Unlock()
+	out := make([]string, len(o.order))
+	copy(out, o.order)
+	return out
+}
+
+// SetStackState records its position in the call order, then delegates.
+func (o *orderRecordingInfra) SetStackState(state *datatypes.JSON) error {
+	o.record("SetStackState")
+	return o.fakeRefreshableInfra.SetStackState(state)
+}
+
+// RefreshStack records its position in the call order, then delegates.
+func (o *orderRecordingInfra) RefreshStack() error {
+	o.record("RefreshStack")
+	return o.fakeRefreshableInfra.RefreshStack()
+}
+
+// DeployInfra records its position in the call order, then delegates.
+func (o *orderRecordingInfra) DeployInfra() error {
+	o.record("DeployInfra")
+	return o.fakeRefreshableInfra.DeployInfra()
+}
+
+// TestSemaphoreBackpressure_Requeue30 pins the non-blocking semaphore
+// acquire: with capacity 2 and blocking deploys, the first two creates
+// get slots and requeue at 120, the next three get (30, nil) without
+// launching a goroutine, and slots freed by completed deploys can be
+// acquired by a subsequent call.
+func TestSemaphoreBackpressure_Requeue30(t *testing.T) {
+	configureSemaphoreTest(t, 2)
+	log := newTestLogger()
+
+	// drive 5 independent instances with blocking deploys
+	var fis [5]*fakeInfra
+	var fls [5]*fakeLifecycle
+	for i := range fis {
+		fis[i] = newFakeInfra()
+		fis[i].setDeploy(infraBlock, nil)
+		fls[i] = newFakeLifecycle()
+		fls[i].setInfra(fis[i])
+	}
+	t.Cleanup(func() {
+		for _, fi := range fis {
+			fi.releaseDeploy()
+		}
+	})
+
+	var requeues [5]int64
+	for i := range fls {
+		requeue, err := HandleInfraCreate(fls[i], log)
+		require.NoError(t, err)
+		requeues[i] = requeue
+	}
+
+	// the slot acquire is synchronous, so exactly the first two launch
+	require.Equal(t, [5]int64{120, 120, 30, 30, 30}, requeues)
+
+	// the two slot holders reach their deploys
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if fis[0].deployCallCount() == 1 && fis[1].deployCallCount() == 1 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	require.Equal(t, 1, fis[0].deployCallCount())
+	require.Equal(t, 1, fis[1].deployCallCount())
+
+	// the three rejected instances launched nothing
+	for i := 2; i < 5; i++ {
+		require.Equal(t, 0, fis[i].deployCallCount())
+	}
+
+	// release the blocked deploys and wait for the slots to free
+	fis[0].releaseDeploy()
+	fis[1].releaseDeploy()
+	waitForSemaphoreDrain(t)
+
+	// a subsequent call acquires a freed slot
+	fl := newFakeLifecycle()
+	requeue, err := HandleInfraCreate(fl, log)
+	require.NoError(t, err)
+	require.Equal(t, int64(120), requeue)
+}
+
+// TestSemaphoreReleaseOnPanic pins the create launch goroutine's recover
+// path: a panicking deploy is recovered, the failure is persisted via
+// SetCreationFailed, and the semaphore slot is released so a subsequent
+// create can acquire it.
+func TestSemaphoreReleaseOnPanic(t *testing.T) {
+	configureSemaphoreTest(t, 1)
+	log := newTestLogger()
+
+	fi := newFakeInfra()
+	fi.setDeploy(infraPanic, nil)
+	fl := newFakeLifecycle()
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraCreate(fl, log)
+	require.NoError(t, err)
+	require.Equal(t, int64(120), requeue)
+
+	// the slot release is the goroutine's last action, so after the drain
+	// the recover path has already persisted the failure
+	waitForSemaphoreDrain(t)
+	require.Equal(t, 1, fi.deployCallCount())
+	require.Equal(t, 1, fl.callCount("SetCreationFailed"))
+
+	// with capacity 1, a successful follow-up launch proves the panicking
+	// goroutine released its slot
+	fl2 := newFakeLifecycle()
+	requeue, err = HandleInfraCreate(fl2, log)
+	require.NoError(t, err)
+	require.Equal(t, int64(120), requeue)
+}
+
+// TestSemaphoreReleaseOnPanic_Delete pins the delete launch goroutine's
+// recover path: a panicking destroy is recovered without persisting any
+// failure (the delete path has no PersistFailure callback, it only logs),
+// and the semaphore slot is released for a subsequent delete.
+func TestSemaphoreReleaseOnPanic_Delete(t *testing.T) {
+	configureSemaphoreTest(t, 1)
+	log := newTestLogger()
+
+	fi := newFakeInfra()
+	fi.setDestroy(infraPanic, nil)
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		DeletionScheduled: timePtr(time.Now().UTC()),
+	})
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraDelete(fl, log)
+	require.NoError(t, err)
+	require.Equal(t, int64(300), requeue)
+
+	// the test process surviving the panic plus a clean drain pins the
+	// recover; the delete path persists nothing on panic
+	waitForSemaphoreDrain(t)
+	require.Equal(t, 1, fi.destroyCallCount())
+	require.Equal(t, 0, fl.callCount("SetCreationFailed"))
+	require.Equal(t, 0, fl.callCount("SaveState"))
+
+	// with capacity 1, a successful follow-up launch proves the panicking
+	// goroutine released its slot
+	fl2 := newFakeLifecycle(&ReconciliationSnapshot{
+		DeletionScheduled: timePtr(time.Now().UTC()),
+	})
+	requeue, err = HandleInfraDelete(fl2, log)
+	require.NoError(t, err)
+	require.Equal(t, int64(300), requeue)
+}
+
+// TestExecuteInfraCreate_RestoreThenRefreshThenDeploy pins the create
+// goroutine's sequencing when existing state is present on a refreshable
+// provider: state is restored first, then refreshed against cloud
+// reality, then deployed.
+func TestExecuteInfraCreate_RestoreThenRefreshThenDeploy(t *testing.T) {
+	configureSemaphoreTest(t, 1)
+	log := newTestLogger()
+
+	inventory := validStackState()
+	oi := newOrderRecordingInfra()
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		ResourceInventory: inventory,
+	})
+	fl.setInfra(oi)
+
+	requeue, err := HandleInfraCreate(fl, log)
+	require.NoError(t, err)
+	require.Equal(t, int64(120), requeue)
+
+	waitForSemaphoreDrain(t)
+
+	require.Equal(
+		t,
+		[]string{"SetStackState", "RefreshStack", "DeployInfra"},
+		oi.callOrder(),
+	)
+	require.Equal(t, 1, oi.refreshCallCount())
+	require.NotNil(t, oi.lastRestoredState())
+	require.JSONEq(t, string(*inventory), string(*oi.lastRestoredState()))
+
+	// the success path completed after the ordered sequence
+	require.Equal(t, 1, fl.callCount("SaveCreateOutputs"))
+	require.Equal(t, 1, fl.callCount("PublishCreateNotification"))
+}
+
+// TestExecuteInfraCreate_NonStreamable_NoWatcher pins that a provider
+// without streaming support runs the create to success with no state
+// watcher: SaveState is the watcher's only writer on the success path,
+// so its count staying at zero proves no watcher streamed state.
+func TestExecuteInfraCreate_NonStreamable_NoWatcher(t *testing.T) {
+	configureSemaphoreTest(t, 1)
+	log := newTestLogger()
+
+	fi := newFakeInfra()
+	fl := newFakeLifecycle()
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraCreate(fl, log)
+	require.NoError(t, err)
+	require.Equal(t, int64(120), requeue)
+
+	waitForSemaphoreDrain(t)
+
+	// success path completed end to end
+	require.Equal(t, 1, fi.deployCallCount())
+	require.Equal(t, 1, fl.callCount("SaveCreateOutputs"))
+	require.NotNil(t, fl.createOutputs())
+	require.JSONEq(t, string(*validStackState()), string(*fl.createOutputs()))
+	require.Equal(t, 1, fl.callCount("PublishCreateNotification"))
+
+	// no existing state, so no restore; no watcher, so no streamed saves
+	require.Equal(t, 0, fi.setStackStateCallCount())
+	require.Equal(t, 0, fl.callCount("SaveState"))
+}
+
+// TestExecuteInfraCreate_DeployError_CapturesStateAndPersistsFailure pins
+// the deploy failure branch: partial state is captured via GetStackState
+// and saved for retry restoration, then the failure is persisted via
+// SetCreationFailed, and the success callbacks never run.
+func TestExecuteInfraCreate_DeployError_CapturesStateAndPersistsFailure(t *testing.T) {
+	configureSemaphoreTest(t, 1)
+	log := newTestLogger()
+
+	errDeploy := errors.New("deploy exploded")
+	fi := newFakeInfra()
+	fi.setDeploy(infraError, errDeploy)
+	fl := newFakeLifecycle()
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraCreate(fl, log)
+	require.NoError(t, err)
+	require.Equal(t, int64(120), requeue)
+
+	waitForSemaphoreDrain(t)
+
+	// partial state captured and saved for the retry
+	require.Equal(t, 1, fi.getStackStateCallCount())
+	saved := fl.savedStateHistory()
+	require.Len(t, saved, 1)
+	require.JSONEq(t, string(*validStackState()), string(*saved[0]))
+
+	// failure persisted, success callbacks skipped
+	require.Equal(t, 1, fl.callCount("SetCreationFailed"))
+	require.Equal(t, 0, fl.callCount("SaveCreateOutputs"))
+	require.Equal(t, 0, fl.callCount("PublishCreateNotification"))
+}
+
+// TestExecuteInfraCreate_VerifyStateFails_PersistsFailure pins the state
+// verification gate: a successful deploy whose captured state contains no
+// resources fails verification, persists the failure, and never invokes
+// the success callback.
+func TestExecuteInfraCreate_VerifyStateFails_PersistsFailure(t *testing.T) {
+	configureSemaphoreTest(t, 1)
+	log := newTestLogger()
+
+	fi := newFakeInfra()
+	fi.setGetStackState(jsonPtr(`{"deployment":{"resources":[]}}`), nil)
+	fl := newFakeLifecycle()
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraCreate(fl, log)
+	require.NoError(t, err)
+	require.Equal(t, int64(120), requeue)
+
+	waitForSemaphoreDrain(t)
+
+	// deploy succeeded but the resource-less state failed verification
+	require.Equal(t, 1, fi.deployCallCount())
+	require.Equal(t, 1, fi.getStackStateCallCount())
+	require.Equal(t, 1, fl.callCount("SetCreationFailed"))
+
+	// the success callback never ran
+	require.Equal(t, 0, fl.callCount("SaveCreateOutputs"))
+	require.Equal(t, 0, fl.callCount("PublishCreateNotification"))
+}
+
+// TestExecuteInfraDelete_InvalidExistingStateJSON_SkipsRestore pins the
+// delete goroutine's corrupt-state guard: invalid existing state JSON
+// skips the restore entirely but the destroy still proceeds and the
+// success callbacks run.
+func TestExecuteInfraDelete_InvalidExistingStateJSON_SkipsRestore(t *testing.T) {
+	configureSemaphoreTest(t, 1)
+	log := newTestLogger()
+
+	fi := newFakeInfra()
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		DeletionScheduled: timePtr(time.Now().UTC()),
+		ResourceInventory: jsonPtr(`{"deployment":{"resources":[`),
+	})
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraDelete(fl, log)
+	require.NoError(t, err)
+	require.Equal(t, int64(300), requeue)
+
+	waitForSemaphoreDrain(t)
+
+	// restore skipped, destroy still ran
+	require.Equal(t, 0, fi.setStackStateCallCount())
+	require.Equal(t, 1, fi.destroyCallCount())
+
+	// success callbacks ran
+	require.Equal(t, 1, fl.callCount("ClearInventory"))
+	require.Equal(t, 1, fl.callCount("PublishDeleteNotification"))
+}
+
+// TestExecuteInfraDelete_DestroyError_CapturesRemainingState pins the
+// destroy failure branch: remaining state is captured via GetStackState
+// and saved so retries know which resources remain, and the success
+// callbacks never run.
+func TestExecuteInfraDelete_DestroyError_CapturesRemainingState(t *testing.T) {
+	configureSemaphoreTest(t, 1)
+	log := newTestLogger()
+
+	errDestroy := errors.New("destroy exploded")
+	fi := newFakeInfra()
+	fi.setDestroy(infraError, errDestroy)
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		DeletionScheduled: timePtr(time.Now().UTC()),
+	})
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraDelete(fl, log)
+	require.NoError(t, err)
+	require.Equal(t, int64(300), requeue)
+
+	waitForSemaphoreDrain(t)
+
+	// remaining state captured and saved for the retry
+	require.Equal(t, 1, fi.destroyCallCount())
+	require.Equal(t, 1, fi.getStackStateCallCount())
+	saved := fl.savedStateHistory()
+	require.Len(t, saved, 1)
+	require.JSONEq(t, string(*validStackState()), string(*saved[0]))
+
+	// success callbacks skipped
+	require.Equal(t, 0, fl.callCount("ClearInventory"))
+	require.Equal(t, 0, fl.callCount("PublishDeleteNotification"))
+}

--- a/internal/provider/fakes_test.go
+++ b/internal/provider/fakes_test.go
@@ -1,0 +1,632 @@
+package provider
+
+import (
+	"errors"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"gorm.io/datatypes"
+)
+
+// compile-time interface satisfaction checks for all fakes.
+var (
+	_ InfraLifecycleProvider = (*fakeLifecycle)(nil)
+	_ InfraProvider          = (*fakeInfra)(nil)
+	_ StreamableProvider     = (*fakeStreamableInfra)(nil)
+	_ RefreshableProvider    = (*fakeRefreshableInfra)(nil)
+	_ Clock                  = (*fakeClock)(nil)
+)
+
+// errFakeInfra is the fallback error returned by infra fakes when a method
+// is set to fail but no specific error was injected.
+var errFakeInfra = errors.New("fakeInfra: injected failure")
+
+// baselineGoroutines holds the goroutine count captured before any test
+// runs. Tests that spawn background goroutines can poll against this
+// baseline to verify cleanup.
+var baselineGoroutines int
+
+// TestMain snapshots the baseline goroutine count, then runs the test
+// binary. It deliberately does nothing else: no global skips, no setup.
+func TestMain(m *testing.M) {
+	baselineGoroutines = runtime.NumGoroutine()
+	os.Exit(m.Run())
+}
+
+// newTestLogger returns a pointer to a discard logger matching the
+// *logr.Logger parameter shape the lifecycle handlers take.
+func newTestLogger() *logr.Logger {
+	l := logr.Discard()
+	return &l
+}
+
+// timePtr returns a pointer to the given time, for building
+// reconciliation snapshots inline.
+func timePtr(t time.Time) *time.Time {
+	return &t
+}
+
+// jsonPtr returns a pointer to the given string as a JSON value, for
+// building resource inventories inline.
+func jsonPtr(s string) *datatypes.JSON {
+	j := datatypes.JSON(s)
+	return &j
+}
+
+// validStackState returns a state JSON in deployment format with one
+// resource, sufficient to pass post-create state verification.
+func validStackState() *datatypes.JSON {
+	return jsonPtr(`{"deployment":{"resources":[{"urn":"urn:fake:resource"}]}}`)
+}
+
+// fakeClock implements Clock with a fixed, advanceable time.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+// newFakeClock returns a clock frozen at the given time.
+func newFakeClock(t time.Time) *fakeClock {
+	return &fakeClock{now: t}
+}
+
+// Now returns the clock's current frozen time.
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+// Advance moves the clock forward by the given duration.
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// infraMode selects the behavior of a fakeInfra deploy or destroy call.
+type infraMode int
+
+const (
+	// infraSucceed makes the call return nil immediately.
+	infraSucceed infraMode = iota
+
+	// infraError makes the call return the injected error, or
+	// errFakeInfra when none was injected.
+	infraError
+
+	// infraPanic makes the call panic, exercising the recover path in
+	// the launch goroutines.
+	infraPanic
+
+	// infraBlock makes the call block until released, so a test can hold
+	// a semaphore slot open and observe backpressure.
+	infraBlock
+)
+
+// fakeInfra implements InfraProvider with per-method programmable
+// behavior and call counters. Safe for concurrent use.
+type fakeInfra struct {
+	mu sync.Mutex
+
+	deployMode infraMode
+	deployErr  error
+
+	destroyMode infraMode
+	destroyErr  error
+
+	deployRelease   chan struct{}
+	deployReleased  bool
+	destroyRelease  chan struct{}
+	destroyReleased bool
+
+	deployCalls   int
+	destroyCalls  int
+	setStateCalls int
+	getStateCalls int
+
+	restoredStates []*datatypes.JSON
+	setStateErr    error
+
+	stackState  *datatypes.JSON
+	getStateErr error
+}
+
+// newFakeInfra returns an infra fake whose deploy and destroy succeed
+// immediately and whose stack state defaults to a valid one-resource
+// deployment so the create success path completes.
+func newFakeInfra() *fakeInfra {
+	return &fakeInfra{
+		deployRelease:  make(chan struct{}),
+		destroyRelease: make(chan struct{}),
+		stackState:     validStackState(),
+	}
+}
+
+// DeployInfra runs the programmed deploy behavior.
+func (f *fakeInfra) DeployInfra() error {
+	f.mu.Lock()
+	f.deployCalls++
+	mode := f.deployMode
+	err := f.deployErr
+	release := f.deployRelease
+	f.mu.Unlock()
+
+	return runInfraMode(mode, err, release, "fakeInfra: deploy panic")
+}
+
+// DestroyInfra runs the programmed destroy behavior.
+func (f *fakeInfra) DestroyInfra() error {
+	f.mu.Lock()
+	f.destroyCalls++
+	mode := f.destroyMode
+	err := f.destroyErr
+	release := f.destroyRelease
+	f.mu.Unlock()
+
+	return runInfraMode(mode, err, release, "fakeInfra: destroy panic")
+}
+
+// runInfraMode executes the shared mode dispatch for deploy and destroy.
+func runInfraMode(
+	mode infraMode,
+	err error,
+	release chan struct{},
+	panicMsg string,
+) error {
+	switch mode {
+	case infraError:
+		if err != nil {
+			return err
+		}
+		return errFakeInfra
+	case infraPanic:
+		panic(panicMsg)
+	case infraBlock:
+		<-release
+		return nil
+	}
+	return nil
+}
+
+// SetStackState records the restored state and returns the injected error.
+func (f *fakeInfra) SetStackState(state *datatypes.JSON) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setStateCalls++
+	f.restoredStates = append(f.restoredStates, state)
+	return f.setStateErr
+}
+
+// GetStackState returns the programmed stack state and error.
+func (f *fakeInfra) GetStackState() (*datatypes.JSON, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getStateCalls++
+	return f.stackState, f.getStateErr
+}
+
+// setDeploy programs the deploy mode and, for infraError, the error
+// returned.
+func (f *fakeInfra) setDeploy(mode infraMode, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deployMode = mode
+	f.deployErr = err
+}
+
+// setDestroy programs the destroy mode and, for infraError, the error
+// returned.
+func (f *fakeInfra) setDestroy(mode infraMode, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.destroyMode = mode
+	f.destroyErr = err
+}
+
+// setGetStackState programs the state and error returned when the
+// lifecycle captures stack state.
+func (f *fakeInfra) setGetStackState(state *datatypes.JSON, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stackState = state
+	f.getStateErr = err
+}
+
+// setSetStackStateErr programs the error returned when the lifecycle
+// restores stack state.
+func (f *fakeInfra) setSetStackStateErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setStateErr = err
+}
+
+// releaseDeploy unblocks a deploy call in infraBlock mode. Idempotent.
+func (f *fakeInfra) releaseDeploy() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.deployReleased {
+		close(f.deployRelease)
+		f.deployReleased = true
+	}
+}
+
+// releaseDestroy unblocks a destroy call in infraBlock mode. Idempotent.
+func (f *fakeInfra) releaseDestroy() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.destroyReleased {
+		close(f.destroyRelease)
+		f.destroyReleased = true
+	}
+}
+
+// deployCallCount returns the number of deploy invocations.
+func (f *fakeInfra) deployCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.deployCalls
+}
+
+// destroyCallCount returns the number of destroy invocations.
+func (f *fakeInfra) destroyCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.destroyCalls
+}
+
+// setStackStateCallCount returns the number of state-restore invocations.
+func (f *fakeInfra) setStackStateCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.setStateCalls
+}
+
+// getStackStateCallCount returns the number of state-capture invocations.
+func (f *fakeInfra) getStackStateCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.getStateCalls
+}
+
+// lastRestoredState returns the state passed to the most recent
+// state-restore call, or nil if none occurred.
+func (f *fakeInfra) lastRestoredState() *datatypes.JSON {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.restoredStates) == 0 {
+		return nil
+	}
+	return f.restoredStates[len(f.restoredStates)-1]
+}
+
+// fakeStreamableInfra implements StreamableProvider by embedding
+// fakeInfra and adding programmable state file path and read behavior.
+type fakeStreamableInfra struct {
+	*fakeInfra
+
+	smu              sync.Mutex
+	stateFilePath    string
+	stateFilePathErr error
+	readState        *datatypes.JSON
+	readStateErr     error
+	readCalls        int
+}
+
+// newFakeStreamableInfra returns a streamable infra fake reporting the
+// given state file path. Pass a path under t.TempDir() so the stream
+// watcher has a real directory to watch.
+func newFakeStreamableInfra(stateFilePath string) *fakeStreamableInfra {
+	return &fakeStreamableInfra{
+		fakeInfra:     newFakeInfra(),
+		stateFilePath: stateFilePath,
+	}
+}
+
+// GetStateFilePath returns the programmed path and error.
+func (f *fakeStreamableInfra) GetStateFilePath() (string, error) {
+	f.smu.Lock()
+	defer f.smu.Unlock()
+	if f.stateFilePathErr != nil {
+		return "", f.stateFilePathErr
+	}
+	return f.stateFilePath, nil
+}
+
+// ReadStateFile returns the programmed state and error.
+func (f *fakeStreamableInfra) ReadStateFile() (*datatypes.JSON, error) {
+	f.smu.Lock()
+	defer f.smu.Unlock()
+	f.readCalls++
+	return f.readState, f.readStateErr
+}
+
+// setStateFilePathErr programs an error for state file path lookups.
+func (f *fakeStreamableInfra) setStateFilePathErr(err error) {
+	f.smu.Lock()
+	defer f.smu.Unlock()
+	f.stateFilePathErr = err
+}
+
+// setReadState programs the state and error returned by state file reads.
+func (f *fakeStreamableInfra) setReadState(state *datatypes.JSON, err error) {
+	f.smu.Lock()
+	defer f.smu.Unlock()
+	f.readState = state
+	f.readStateErr = err
+}
+
+// readStateCallCount returns the number of state file read invocations.
+func (f *fakeStreamableInfra) readStateCallCount() int {
+	f.smu.Lock()
+	defer f.smu.Unlock()
+	return f.readCalls
+}
+
+// fakeRefreshableInfra implements RefreshableProvider by embedding
+// fakeInfra and adding programmable refresh behavior.
+type fakeRefreshableInfra struct {
+	*fakeInfra
+
+	rmu          sync.Mutex
+	refreshErr   error
+	refreshCalls int
+}
+
+// newFakeRefreshableInfra returns a refreshable infra fake whose refresh
+// succeeds by default.
+func newFakeRefreshableInfra() *fakeRefreshableInfra {
+	return &fakeRefreshableInfra{
+		fakeInfra: newFakeInfra(),
+	}
+}
+
+// RefreshStack returns the programmed refresh error.
+func (f *fakeRefreshableInfra) RefreshStack() error {
+	f.rmu.Lock()
+	defer f.rmu.Unlock()
+	f.refreshCalls++
+	return f.refreshErr
+}
+
+// setRefreshErr programs the error returned by stack refreshes.
+func (f *fakeRefreshableInfra) setRefreshErr(err error) {
+	f.rmu.Lock()
+	defer f.rmu.Unlock()
+	f.refreshErr = err
+}
+
+// refreshCallCount returns the number of refresh invocations.
+func (f *fakeRefreshableInfra) refreshCallCount() int {
+	f.rmu.Lock()
+	defer f.rmu.Unlock()
+	return f.refreshCalls
+}
+
+// fakeLifecycle implements InfraLifecycleProvider with per-method call
+// counters, per-method error injection, and a programmable sequence of
+// reconciliation snapshots. Safe for concurrent use.
+type fakeLifecycle struct {
+	mu sync.Mutex
+
+	calls map[string]int
+	errs  map[string]error
+
+	snaps     []*ReconciliationSnapshot
+	snapIndex int
+
+	infra          InfraProvider
+	createComplete bool
+
+	savedStates       []*datatypes.JSON
+	createOutputState *datatypes.JSON
+}
+
+// newFakeLifecycle returns a lifecycle fake that walks the given
+// reconciliation snapshots in order: each call consumes the next
+// snapshot, and once exhausted the last snapshot repeats. With no
+// snapshots, an empty snapshot (a brand new create request) repeats.
+// The built infra defaults to a fresh fakeInfra.
+func newFakeLifecycle(snaps ...*ReconciliationSnapshot) *fakeLifecycle {
+	return &fakeLifecycle{
+		calls: make(map[string]int),
+		errs:  make(map[string]error),
+		snaps: snaps,
+		infra: newFakeInfra(),
+	}
+}
+
+// recordSimple counts a call and returns its injected error, if any.
+func (f *fakeLifecycle) recordSimple(method string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls[method]++
+	return f.errs[method]
+}
+
+// GetReconciliation counts the call and returns the next snapshot in the
+// programmed sequence. An injected error is returned without advancing
+// the sequence. Callers must not mutate returned snapshots.
+func (f *fakeLifecycle) GetReconciliation() (*ReconciliationSnapshot, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls["GetReconciliation"]++
+	if err := f.errs["GetReconciliation"]; err != nil {
+		return nil, err
+	}
+	if len(f.snaps) == 0 {
+		return &ReconciliationSnapshot{}, nil
+	}
+	snap := f.snaps[f.snapIndex]
+	if f.snapIndex < len(f.snaps)-1 {
+		f.snapIndex++
+	}
+	return snap, nil
+}
+
+// BuildInfra counts the call and returns the configured infra, or the
+// injected error.
+func (f *fakeLifecycle) BuildInfra() (InfraProvider, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls["BuildInfra"]++
+	if err := f.errs["BuildInfra"]; err != nil {
+		return nil, err
+	}
+	return f.infra, nil
+}
+
+// IsCreateComplete counts the call and returns the programmed completion
+// flag, or the injected error.
+func (f *fakeLifecycle) IsCreateComplete() (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls["IsCreateComplete"]++
+	if err := f.errs["IsCreateComplete"]; err != nil {
+		return false, err
+	}
+	return f.createComplete, nil
+}
+
+// OnCreateConfirmed counts the call and returns its injected error.
+func (f *fakeLifecycle) OnCreateConfirmed(infra InfraProvider) error {
+	return f.recordSimple("OnCreateConfirmed")
+}
+
+// SaveCreateOutputs counts the call, records the final state, and
+// returns its injected error.
+func (f *fakeLifecycle) SaveCreateOutputs(infra InfraProvider, state *datatypes.JSON) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls["SaveCreateOutputs"]++
+	f.createOutputState = state
+	return f.errs["SaveCreateOutputs"]
+}
+
+// OnDeleteConfirmed counts the call and returns its injected error.
+func (f *fakeLifecycle) OnDeleteConfirmed(infra InfraProvider) error {
+	return f.recordSimple("OnDeleteConfirmed")
+}
+
+// AckCreation counts the call and returns its injected error.
+func (f *fakeLifecycle) AckCreation() error {
+	return f.recordSimple("AckCreation")
+}
+
+// RefreshCreationAck counts the call and returns its injected error.
+func (f *fakeLifecycle) RefreshCreationAck() error {
+	return f.recordSimple("RefreshCreationAck")
+}
+
+// SetCreationFailed counts the call and returns its injected error.
+func (f *fakeLifecycle) SetCreationFailed() error {
+	return f.recordSimple("SetCreationFailed")
+}
+
+// ConfirmCreation counts the call and returns its injected error.
+func (f *fakeLifecycle) ConfirmCreation() error {
+	return f.recordSimple("ConfirmCreation")
+}
+
+// AckDeletion counts the call and returns its injected error.
+func (f *fakeLifecycle) AckDeletion() error {
+	return f.recordSimple("AckDeletion")
+}
+
+// RefreshDeletionAck counts the call and returns its injected error.
+func (f *fakeLifecycle) RefreshDeletionAck() error {
+	return f.recordSimple("RefreshDeletionAck")
+}
+
+// ConfirmDeletion counts the call and returns its injected error.
+func (f *fakeLifecycle) ConfirmDeletion() error {
+	return f.recordSimple("ConfirmDeletion")
+}
+
+// SaveState counts the call, appends the state to the saved history, and
+// returns its injected error.
+func (f *fakeLifecycle) SaveState(state *datatypes.JSON) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls["SaveState"]++
+	f.savedStates = append(f.savedStates, state)
+	return f.errs["SaveState"]
+}
+
+// ClearInventory counts the call and returns its injected error.
+func (f *fakeLifecycle) ClearInventory() error {
+	return f.recordSimple("ClearInventory")
+}
+
+// PublishCreateNotification counts the call and returns its injected error.
+func (f *fakeLifecycle) PublishCreateNotification() error {
+	return f.recordSimple("PublishCreateNotification")
+}
+
+// PublishDeleteNotification counts the call and returns its injected error.
+func (f *fakeLifecycle) PublishDeleteNotification() error {
+	return f.recordSimple("PublishDeleteNotification")
+}
+
+// setErr injects an error for the named interface method; passing nil
+// clears the injection.
+func (f *fakeLifecycle) setErr(method string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err == nil {
+		delete(f.errs, method)
+		return
+	}
+	f.errs[method] = err
+}
+
+// setInfra replaces the infra returned when the lifecycle builds one.
+func (f *fakeLifecycle) setInfra(infra InfraProvider) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.infra = infra
+}
+
+// setCreateComplete programs the completion flag for create checks.
+func (f *fakeLifecycle) setCreateComplete(complete bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.createComplete = complete
+}
+
+// pushSnapshot appends a snapshot to the programmed sequence so tests
+// can extend the walk mid-flight.
+func (f *fakeLifecycle) pushSnapshot(snap *ReconciliationSnapshot) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.snaps = append(f.snaps, snap)
+}
+
+// callCount returns how many times the named interface method was called.
+func (f *fakeLifecycle) callCount(method string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[method]
+}
+
+// savedStateHistory returns a copy of all states passed to SaveState in
+// call order.
+func (f *fakeLifecycle) savedStateHistory() []*datatypes.JSON {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*datatypes.JSON, len(f.savedStates))
+	copy(out, f.savedStates)
+	return out
+}
+
+// createOutputs returns the state passed to the most recent
+// SaveCreateOutputs call, or nil if none occurred.
+func (f *fakeLifecycle) createOutputs() *datatypes.JSON {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.createOutputState
+}

--- a/internal/provider/goroutine_test.go
+++ b/internal/provider/goroutine_test.go
@@ -1,0 +1,345 @@
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+// fastRefreshConfig returns a lifecycle config with a millisecond-scale
+// refresh interval so refreshAck tests tick quickly. All other tunables
+// keep production-scale values that the tests never reach.
+func fastRefreshConfig() LifecycleConfig {
+	return LifecycleConfig{
+		StaleAckThreshold: 240 * time.Second,
+		RefreshInterval:   5 * time.Millisecond,
+		SemaphoreCapacity: 5,
+		PersistRetries:    1,
+		PersistRetryDelay: time.Millisecond,
+	}
+}
+
+// TestRefreshAck_QuitClean pins the quit-channel branch of refreshAck:
+// the loop ticks on the configured refresh interval, returns promptly
+// once quit is signalled, and stops invoking the refresh function after
+// it returns.
+func TestRefreshAck_QuitClean(t *testing.T) {
+	restore := setLifecycleConfig(fastRefreshConfig())
+	t.Cleanup(restore)
+
+	var calls int64
+	refresh := func() error {
+		atomic.AddInt64(&calls, 1)
+		return nil
+	}
+
+	quit := make(chan bool, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		refreshAck(refresh, quit, newTestLogger())
+	}()
+
+	// prove the loop is ticking before signalling quit
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt64(&calls) >= 2
+	}, 10*time.Second, time.Millisecond, "refreshAck should tick on the refresh interval")
+
+	quit <- true
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("refreshAck did not return after quit signal")
+	}
+
+	// after the loop has returned, the call count must freeze; the grace
+	// window spans many refresh intervals to catch a stray ticker
+	settled := atomic.LoadInt64(&calls)
+	assert.Never(t, func() bool {
+		return atomic.LoadInt64(&calls) != settled
+	}, 100*time.Millisecond, 5*time.Millisecond, "refresh calls must stop after refreshAck returns")
+}
+
+// TestRefreshAck_RefreshErrorDoesNotBlock pins the error branch of the
+// tick case: refresh failures are logged and swallowed, the loop keeps
+// ticking through them, and quit still exits the loop promptly.
+func TestRefreshAck_RefreshErrorDoesNotBlock(t *testing.T) {
+	restore := setLifecycleConfig(fastRefreshConfig())
+	t.Cleanup(restore)
+
+	var calls int64
+	refresh := func() error {
+		if atomic.AddInt64(&calls, 1) <= 3 {
+			return errFakeInfra
+		}
+		return nil
+	}
+
+	quit := make(chan bool, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		refreshAck(refresh, quit, newTestLogger())
+	}()
+
+	// the loop must tick well past the three failing calls
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt64(&calls) >= 6
+	}, 10*time.Second, time.Millisecond, "refreshAck should keep ticking through refresh errors")
+
+	quit <- true
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("refreshAck did not return after quit signal")
+	}
+}
+
+// streamHarness wires a fake streamable provider, a save recorder, and
+// the channels needed to drive a streamState goroutine under test. The
+// watched path is built through a real PulumiWorkspace rooted in a temp
+// dir, matching production path construction exactly.
+type streamHarness struct {
+	t     *testing.T
+	infra *fakeStreamableInfra
+	path  string
+
+	mu    sync.Mutex
+	saved []*datatypes.JSON
+
+	quit chan bool
+	done chan struct{}
+}
+
+// newStreamHarness resolves a state file path via PulumiWorkspace under
+// t.TempDir() and returns a harness around a fake streamable provider
+// reporting that path.
+func newStreamHarness(t *testing.T) *streamHarness {
+	t.Helper()
+	ws := NewPulumiWorkspace("test-instance", "test-project", WithStateDirRoot(t.TempDir()))
+	path, err := ws.GetStateFilePath()
+	require.NoError(t, err)
+	return &streamHarness{
+		t:     t,
+		infra: newFakeStreamableInfra(path),
+		path:  path,
+		quit:  make(chan bool, 1),
+		done:  make(chan struct{}),
+	}
+}
+
+// start launches streamState in a goroutine; done closes when it
+// returns. A cleanup sends a non-blocking quit so a failed test never
+// leaks the watcher goroutine.
+func (h *streamHarness) start() {
+	go func() {
+		defer close(h.done)
+		streamState(h.infra, h.saveState, h.quit, newTestLogger())
+	}()
+	h.t.Cleanup(func() {
+		select {
+		case h.quit <- true:
+		default:
+		}
+	})
+}
+
+// saveState records every state pushed by streamState.
+func (h *streamHarness) saveState(state *datatypes.JSON) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.saved = append(h.saved, state)
+	return nil
+}
+
+// saveCount returns the number of recorded saves.
+func (h *streamHarness) saveCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.saved)
+}
+
+// lastSaved returns the most recently recorded state, or nil if no save
+// occurred.
+func (h *streamHarness) lastSaved() *datatypes.JSON {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.saved) == 0 {
+		return nil
+	}
+	return h.saved[len(h.saved)-1]
+}
+
+// writeStateFile writes content to the watched state file to fire a
+// real fsnotify event, creating the parent directory if needed. Uses
+// assert (not require) so it is safe inside Eventually conditions,
+// which run on a non-test goroutine.
+func (h *streamHarness) writeStateFile(content string) {
+	if !assert.NoError(h.t, os.MkdirAll(filepath.Dir(h.path), 0755)) {
+		return
+	}
+	assert.NoError(h.t, os.WriteFile(h.path, []byte(content), 0644))
+}
+
+// writeSiblingFile writes a differently named file in the watched
+// directory; its events must be filtered out by base filename.
+func (h *streamHarness) writeSiblingFile(content string) {
+	sibling := filepath.Join(filepath.Dir(h.path), "sibling.json")
+	if !assert.NoError(h.t, os.MkdirAll(filepath.Dir(h.path), 0755)) {
+		return
+	}
+	assert.NoError(h.t, os.WriteFile(sibling, []byte(content), 0644))
+}
+
+// sendQuit signals streamState to stop.
+func (h *streamHarness) sendQuit() {
+	h.quit <- true
+}
+
+// waitDone blocks until streamState returns or fails the test at the
+// deadline. Call only from the test goroutine.
+func (h *streamHarness) waitDone(deadline time.Duration) {
+	h.t.Helper()
+	select {
+	case <-h.done:
+	case <-time.After(deadline):
+		h.t.Fatal("streamState did not return before deadline")
+	}
+}
+
+// TestStreamState_ValidJSON_SavesImmediately pins the happy streaming
+// path: streamState creates the state directory itself, watches it, and
+// on a real fsnotify write event reads the state file and pushes the
+// exact bytes through the save callback.
+func TestStreamState_ValidJSON_SavesImmediately(t *testing.T) {
+	h := newStreamHarness(t)
+	want := validStackState()
+	h.infra.setReadState(want, nil)
+
+	h.start()
+
+	// streamState must create the watch directory before the test writes
+	// anything; this pins the production MkdirAll on the parent dir
+	stateDir := filepath.Dir(h.path)
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(stateDir)
+		return err == nil
+	}, 10*time.Second, 10*time.Millisecond, "streamState should create the state directory")
+
+	// rewrite the file until a save lands; the watcher registration is
+	// not observable, so poll-writing absorbs the startup race
+	require.Eventually(t, func() bool {
+		h.writeStateFile(string(*want))
+		return h.saveCount() >= 1
+	}, 10*time.Second, 50*time.Millisecond, "state file write should trigger a save")
+
+	got := h.lastSaved()
+	require.NotNil(t, got)
+	assert.Equal(t, string(*want), string(*got), "saved state must match the bytes read from the state file")
+	assert.GreaterOrEqual(t, h.infra.readStateCallCount(), 1, "state file event should trigger a read")
+
+	h.sendQuit()
+	h.waitDone(5 * time.Second)
+}
+
+// TestStreamState_PartialJSON_Skipped pins the invalid-JSON guard: a
+// state file read returning partial JSON is skipped without saving and
+// without ending the loop, and a later valid read still saves.
+func TestStreamState_PartialJSON_Skipped(t *testing.T) {
+	h := newStreamHarness(t)
+	partial := jsonPtr(`{"deployment":{"resources":[`)
+	h.infra.setReadState(partial, nil)
+
+	h.start()
+
+	// rewrite the file until an event has been consumed, proven by the
+	// read counter advancing
+	require.Eventually(t, func() bool {
+		h.writeStateFile(string(*partial))
+		return h.infra.readStateCallCount() >= 1
+	}, 10*time.Second, 50*time.Millisecond, "state file write should trigger a read")
+
+	// invalid JSON must never reach the save callback
+	assert.Never(t, func() bool {
+		return h.saveCount() > 0
+	}, 300*time.Millisecond, 20*time.Millisecond, "partial JSON must not be saved")
+
+	// prove the loop survived the skip: a valid read now saves
+	want := validStackState()
+	h.infra.setReadState(want, nil)
+	require.Eventually(t, func() bool {
+		h.writeStateFile(string(*want))
+		return h.saveCount() >= 1
+	}, 10*time.Second, 50*time.Millisecond, "valid state after a skipped partial write should save")
+
+	h.sendQuit()
+	h.waitDone(5 * time.Second)
+}
+
+// TestStreamState_QuitOrdering_NoLateWrite pins the quit ordering
+// contract: once quit has been honored and streamState has returned, a
+// subsequent state file write produces no save.
+func TestStreamState_QuitOrdering_NoLateWrite(t *testing.T) {
+	h := newStreamHarness(t)
+	want := validStackState()
+	h.infra.setReadState(want, nil)
+
+	h.start()
+
+	// confirm the watcher is live before quitting so the quit interrupts
+	// an active watch rather than a not-yet-started one
+	require.Eventually(t, func() bool {
+		h.writeStateFile(string(*want))
+		return h.saveCount() >= 1
+	}, 10*time.Second, 50*time.Millisecond, "state file write should trigger a save before quit")
+
+	h.sendQuit()
+	h.waitDone(5 * time.Second)
+
+	// the count is frozen once the goroutine has returned; writes after
+	// quit must never produce a late save
+	settled := h.saveCount()
+	h.writeStateFile(string(*want))
+	assert.Never(t, func() bool {
+		return h.saveCount() > settled
+	}, 500*time.Millisecond, 25*time.Millisecond, "no save may occur after quit was honored")
+}
+
+// TestStreamState_NonStateFileEvent_Ignored pins the filename filter:
+// events for other files in the watched directory trigger neither a
+// state file read nor a save, while the loop stays live for real state
+// file events.
+func TestStreamState_NonStateFileEvent_Ignored(t *testing.T) {
+	h := newStreamHarness(t)
+	want := validStackState()
+	h.infra.setReadState(want, nil)
+
+	h.start()
+
+	// hammer the watched directory with sibling file writes; none may
+	// trigger a read or a save
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		h.writeSiblingFile(`{"unrelated":true}`)
+		require.Zero(t, h.infra.readStateCallCount(), "sibling file events must not trigger state file reads")
+		require.Zero(t, h.saveCount(), "sibling file events must not trigger saves")
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	// prove the watcher was live the whole time: a real state file write
+	// still produces a save
+	require.Eventually(t, func() bool {
+		h.writeStateFile(string(*want))
+		return h.saveCount() >= 1
+	}, 10*time.Second, 50*time.Millisecond, "state file write should still save after sibling events")
+
+	h.sendQuit()
+	h.waitDone(5 * time.Second)
+}

--- a/internal/provider/handle_create_test.go
+++ b/internal/provider/handle_create_test.go
@@ -1,0 +1,314 @@
+package provider
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestConfig returns lifecycle tunables for create handler tests:
+// production stale threshold, a refresh interval long enough that the
+// ack refresher never ticks, a single semaphore slot, and fast persist
+// retries so failure paths drain quickly.
+func createTestConfig() LifecycleConfig {
+	return LifecycleConfig{
+		StaleAckThreshold: 240 * time.Second,
+		RefreshInterval:   time.Hour,
+		SemaphoreCapacity: 1,
+		PersistRetries:    1,
+		PersistRetryDelay: time.Millisecond,
+	}
+}
+
+// waitForCreateCond polls cond until it returns true or a generous
+// deadline passes, then fails the test. Used only to drain background
+// goroutines, never to assert timing-dependent logic.
+func waitForCreateCond(t *testing.T, desc string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", desc)
+}
+
+// TestHandleInfraCreate_AlreadyConfirmed_EarlyReturn pins the branch
+// where CreationConfirmed is already set: the handler returns (0, nil)
+// after the initial fetch with no further calls on the provider.
+func TestHandleInfraCreate_AlreadyConfirmed_EarlyReturn(t *testing.T) {
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		CreationConfirmed: timePtr(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+	})
+
+	requeue, err := HandleInfraCreate(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), requeue)
+	assert.Equal(t, 1, fl.callCount("GetReconciliation"))
+	assert.Equal(t, 0, fl.callCount("IsCreateComplete"))
+	assert.Equal(t, 0, fl.callCount("AckCreation"))
+	assert.Equal(t, 0, fl.callCount("BuildInfra"))
+	assert.Equal(t, 0, fl.callCount("ConfirmCreation"))
+}
+
+// TestHandleInfraCreate_AckedComplete_ConfirmsInOrder pins the branch
+// where creation is acknowledged, not failed, and complete: the handler
+// builds infra, runs post-creation work, confirms creation, and returns
+// (0, nil) without re-acking or launching. The fakes record counts, not
+// sequence, so the BuildInfra -> OnCreateConfirmed -> ConfirmCreation
+// order is pinned indirectly by the error-propagation test below, which
+// shows a post-creation failure prevents confirmation.
+func TestHandleInfraCreate_AckedComplete_ConfirmsInOrder(t *testing.T) {
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		CreationAcknowledged: timePtr(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+	})
+	fl.setCreateComplete(true)
+	fi := newFakeInfra()
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraCreate(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), requeue)
+	assert.Equal(t, 1, fl.callCount("IsCreateComplete"))
+	assert.Equal(t, 1, fl.callCount("BuildInfra"))
+	assert.Equal(t, 1, fl.callCount("OnCreateConfirmed"))
+	assert.Equal(t, 1, fl.callCount("ConfirmCreation"))
+
+	// the confirm path never re-acks or deploys
+	assert.Equal(t, 0, fl.callCount("AckCreation"))
+	assert.Equal(t, 0, fi.deployCallCount())
+	assert.Equal(t, int64(0), inFlightCount())
+}
+
+// TestHandleInfraCreate_OnCreateConfirmedError_Propagates pins the
+// branch where post-creation work fails: the wrapped error is returned
+// to the reconciler for retry and ConfirmCreation is never called, so
+// the create is not marked confirmed past a failed post-creation step.
+func TestHandleInfraCreate_OnCreateConfirmedError_Propagates(t *testing.T) {
+	errPostCreate := errors.New("post-creation work failed")
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		CreationAcknowledged: timePtr(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+	})
+	fl.setCreateComplete(true)
+	fl.setErr("OnCreateConfirmed", errPostCreate)
+
+	requeue, err := HandleInfraCreate(fl, newTestLogger())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errPostCreate)
+	assert.Contains(t, err.Error(), "failed to run post-creation work")
+	assert.Equal(t, int64(0), requeue)
+	assert.Equal(t, 1, fl.callCount("OnCreateConfirmed"))
+	assert.Equal(t, 0, fl.callCount("ConfirmCreation"))
+}
+
+// TestHandleInfraCreate_AckedIncomplete_FreshAck_Requeue120 pins the
+// branch where creation is acknowledged but incomplete and the ack is
+// still fresh: the handler requeues at 120 seconds without re-acking
+// or relaunching.
+func TestHandleInfraCreate_AckedIncomplete_FreshAck_Requeue120(t *testing.T) {
+	restoreConfig := setLifecycleConfig(createTestConfig())
+	t.Cleanup(restoreConfig)
+
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	restoreClock := setLifecycleClock(newFakeClock(base))
+	t.Cleanup(restoreClock)
+
+	// acked at the clock's current time: zero elapsed, well inside the
+	// stale threshold
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		CreationAcknowledged: timePtr(base),
+	})
+
+	requeue, err := HandleInfraCreate(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(120), requeue)
+	assert.Equal(t, 1, fl.callCount("IsCreateComplete"))
+	assert.Equal(t, 0, fl.callCount("AckCreation"))
+	assert.Equal(t, 0, fl.callCount("BuildInfra"))
+	assert.Equal(t, int64(0), inFlightCount())
+}
+
+// TestHandleInfraCreate_StaleAck_Relaunches pins the branch where
+// creation is acknowledged but incomplete and the ack has gone stale:
+// the handler re-acks and launches the create goroutine, indicating the
+// prior operation was interrupted.
+func TestHandleInfraCreate_StaleAck_Relaunches(t *testing.T) {
+	restoreConfig := setLifecycleConfig(createTestConfig())
+	t.Cleanup(restoreConfig)
+
+	// clock sits one second past the stale threshold relative to the ack
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	restoreClock := setLifecycleClock(newFakeClock(base.Add(241 * time.Second)))
+	t.Cleanup(restoreClock)
+
+	fi := newFakeInfra()
+	fi.setDeploy(infraBlock, nil)
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		CreationAcknowledged: timePtr(base),
+	})
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraCreate(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(120), requeue)
+	assert.Equal(t, 1, fl.callCount("AckCreation"))
+	assert.Equal(t, 1, fl.callCount("BuildInfra"))
+
+	// confirm the goroutine launched, then drain it
+	waitForCreateCond(t, "deploy launch", func() bool {
+		return fi.deployCallCount() == 1
+	})
+	fi.releaseDeploy()
+	waitForCreateCond(t, "in-flight drain", func() bool {
+		return inFlightCount() == 0
+	})
+}
+
+// TestHandleInfraCreate_NewRequest_AcksBuildsLaunches pins the brand
+// new create path: no ack on the snapshot, so the handler acks, builds
+// infra, re-fetches reconciliation for the deletion check, launches the
+// create goroutine, and returns (120, nil).
+func TestHandleInfraCreate_NewRequest_AcksBuildsLaunches(t *testing.T) {
+	restoreConfig := setLifecycleConfig(createTestConfig())
+	t.Cleanup(restoreConfig)
+
+	fi := newFakeInfra()
+	fi.setDeploy(infraBlock, nil)
+	fl := newFakeLifecycle()
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraCreate(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(120), requeue)
+	assert.Equal(t, 1, fl.callCount("AckCreation"))
+	assert.Equal(t, 1, fl.callCount("BuildInfra"))
+
+	// initial fetch plus the pre-launch deletion-scheduled check; deploy
+	// is still blocked, so the success callback has not fetched yet
+	assert.Equal(t, 2, fl.callCount("GetReconciliation"))
+
+	// confirm the goroutine launched, then drain it
+	waitForCreateCond(t, "deploy launch", func() bool {
+		return fi.deployCallCount() == 1
+	})
+	fi.releaseDeploy()
+	waitForCreateCond(t, "in-flight drain", func() bool {
+		return inFlightCount() == 0
+	})
+}
+
+// TestHandleInfraCreate_AckCreationError pins the branch where the
+// creation acknowledgement write fails: the wrapped error is returned
+// and nothing is built or launched.
+func TestHandleInfraCreate_AckCreationError(t *testing.T) {
+	errAck := errors.New("ack write failed")
+	fl := newFakeLifecycle()
+	fl.setErr("AckCreation", errAck)
+
+	requeue, err := HandleInfraCreate(fl, newTestLogger())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errAck)
+	assert.Contains(t, err.Error(), "failed to acknowledge creation")
+	assert.Equal(t, int64(0), requeue)
+	assert.Equal(t, 0, fl.callCount("BuildInfra"))
+	assert.Equal(t, int64(0), inFlightCount())
+}
+
+// TestHandleInfraCreate_DeletionScheduledBeforeLaunch_Aborts pins the
+// pre-launch deletion check: when the second reconciliation fetch shows
+// DeletionScheduled set, the handler aborts with (0, nil) and never
+// deploys, leaving the field clear for the delete handler.
+func TestHandleInfraCreate_DeletionScheduledBeforeLaunch_Aborts(t *testing.T) {
+	fi := newFakeInfra()
+	fl := newFakeLifecycle(
+		&ReconciliationSnapshot{},
+		&ReconciliationSnapshot{
+			DeletionScheduled: timePtr(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+		},
+	)
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraCreate(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), requeue)
+	assert.Equal(t, 1, fl.callCount("AckCreation"))
+	assert.Equal(t, 1, fl.callCount("BuildInfra"))
+	assert.Equal(t, 2, fl.callCount("GetReconciliation"))
+	assert.Equal(t, 0, fi.deployCallCount())
+	assert.Equal(t, int64(0), inFlightCount())
+}
+
+// TestHandleInfraCreate_DeletionScheduledDuringInfra_SuppressesNotification
+// pins the success-callback deletion check: when deletion is scheduled
+// while infrastructure is being created, the callback still saves the
+// create outputs but suppresses the create notification so the delete
+// handler proceeds. Driven through a real launch with a blocked deploy
+// so the callback runs on the production goroutine wiring.
+func TestHandleInfraCreate_DeletionScheduledDuringInfra_SuppressesNotification(t *testing.T) {
+	restoreConfig := setLifecycleConfig(createTestConfig())
+	t.Cleanup(restoreConfig)
+
+	fi := newFakeInfra()
+	fi.setDeploy(infraBlock, nil)
+
+	// snapshots: initial fetch sees a new create, the pre-launch check is
+	// clear, and the success-callback fetch sees deletion scheduled
+	fl := newFakeLifecycle(
+		&ReconciliationSnapshot{},
+		&ReconciliationSnapshot{},
+		&ReconciliationSnapshot{
+			DeletionScheduled: timePtr(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+		},
+	)
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraCreate(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(120), requeue)
+
+	// let the deploy finish so the success callback runs, then drain
+	waitForCreateCond(t, "deploy launch", func() bool {
+		return fi.deployCallCount() == 1
+	})
+	fi.releaseDeploy()
+	waitForCreateCond(t, "in-flight drain", func() bool {
+		return inFlightCount() == 0
+	})
+
+	// outputs saved, notification suppressed
+	assert.Equal(t, 1, fl.callCount("SaveCreateOutputs"))
+	assert.Equal(t, validStackState(), fl.createOutputs())
+	assert.Equal(t, 0, fl.callCount("PublishCreateNotification"))
+}
+
+// TestHandleInfraCreate_GetReconciliationError_FirstFetch pins the
+// branch where the initial reconciliation fetch fails: the wrapped
+// error is returned and no state transitions occur.
+func TestHandleInfraCreate_GetReconciliationError_FirstFetch(t *testing.T) {
+	errFetch := errors.New("api unavailable")
+	fl := newFakeLifecycle()
+	fl.setErr("GetReconciliation", errFetch)
+
+	requeue, err := HandleInfraCreate(fl, newTestLogger())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errFetch)
+	assert.Contains(t, err.Error(), "failed to get reconciliation state")
+	assert.Equal(t, int64(0), requeue)
+	assert.Equal(t, 0, fl.callCount("AckCreation"))
+	assert.Equal(t, 0, fl.callCount("BuildInfra"))
+}

--- a/internal/provider/handle_delete_test.go
+++ b/internal/provider/handle_delete_test.go
@@ -1,0 +1,316 @@
+package provider
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deleteTestBase is the frozen reference time used by the delete handler
+// tests for fresh/stale acknowledgement timestamps.
+var deleteTestBase = time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+// drainDeleteOps waits until all in-flight infrastructure operations have
+// finished and released their semaphore slots, so the t.Cleanup restore of
+// the lifecycle config cannot swap the semaphore out from under a goroutine
+// that still holds a slot.
+func drainDeleteOps(t *testing.T) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return inFlightCount() == 0 && len(infraSemaphore) == 0
+	}, 5*time.Second, 5*time.Millisecond, "in-flight infrastructure operations did not drain")
+}
+
+// TestHandleInfraDelete_NotScheduled_Error pins the validation branch: a
+// delete notification for an instance with no DeletionScheduled timestamp
+// returns the "received but not scheduled" error and never acknowledges or
+// builds infra.
+func TestHandleInfraDelete_NotScheduled_Error(t *testing.T) {
+	// zero snapshots means an empty snapshot repeats: DeletionScheduled nil
+	fl := newFakeLifecycle()
+
+	requeue, err := HandleInfraDelete(fl, newTestLogger())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "received but not scheduled")
+	assert.Equal(t, int64(0), requeue)
+	assert.Equal(t, 1, fl.callCount("GetReconciliation"))
+	assert.Equal(t, 0, fl.callCount("AckDeletion"))
+	assert.Equal(t, 0, fl.callCount("BuildInfra"))
+}
+
+// TestHandleInfraDelete_AlreadyConfirmed_EarlyReturn pins the idempotency
+// branch: when DeletionConfirmed is already set the handler returns (0, nil)
+// without acknowledging, building infra, or launching anything.
+func TestHandleInfraDelete_AlreadyConfirmed_EarlyReturn(t *testing.T) {
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		DeletionScheduled: timePtr(deleteTestBase.Add(-time.Hour)),
+		DeletionConfirmed: timePtr(deleteTestBase.Add(-time.Minute)),
+	})
+
+	requeue, err := HandleInfraDelete(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), requeue)
+	assert.Equal(t, 1, fl.callCount("GetReconciliation"))
+	assert.Equal(t, 0, fl.callCount("AckDeletion"))
+	assert.Equal(t, 0, fl.callCount("BuildInfra"))
+	assert.Equal(t, int64(0), inFlightCount())
+}
+
+// TestHandleInfraDelete_CrossReplicaSafety_Requeue60 pins the cross-replica
+// guard: a fresh CreationAcknowledged with no CreationConfirmed means a
+// create is in progress on some replica, so the delete requeues at 60
+// seconds without launching.
+func TestHandleInfraDelete_CrossReplicaSafety_Requeue60(t *testing.T) {
+	restoreCfg := setLifecycleConfig(testLifecycleConfig())
+	t.Cleanup(restoreCfg)
+	clk := newFakeClock(deleteTestBase)
+	restoreClk := setLifecycleClock(clk)
+	t.Cleanup(restoreClk)
+
+	// ack aged one minute against a 240 second threshold: fresh
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		DeletionScheduled:    timePtr(deleteTestBase.Add(-time.Hour)),
+		CreationAcknowledged: timePtr(deleteTestBase.Add(-time.Minute)),
+	})
+
+	requeue, err := HandleInfraDelete(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(60), requeue)
+	assert.Equal(t, 1, fl.callCount("GetReconciliation"))
+	assert.Equal(t, 0, fl.callCount("AckDeletion"))
+	assert.Equal(t, 0, fl.callCount("BuildInfra"))
+	assert.Equal(t, int64(0), inFlightCount())
+}
+
+// TestHandleInfraDelete_StaleCreateAck_AllowsDelete pins the guard's stale
+// escape hatch: when the CreationAcknowledged timestamp has gone stale the
+// create is presumed interrupted, the guard passes, and the delete proceeds
+// to acknowledge, build infra, and launch the destroy goroutine.
+func TestHandleInfraDelete_StaleCreateAck_AllowsDelete(t *testing.T) {
+	cfg := testLifecycleConfig()
+	cfg.SemaphoreCapacity = 1
+	restoreCfg := setLifecycleConfig(cfg)
+	t.Cleanup(restoreCfg)
+	clk := newFakeClock(deleteTestBase)
+	restoreClk := setLifecycleClock(clk)
+	t.Cleanup(restoreClk)
+
+	fi := newFakeInfra()
+	fi.setDestroy(infraBlock, nil)
+	// ack aged ten minutes against a 240 second threshold: stale
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		DeletionScheduled:    timePtr(deleteTestBase.Add(-time.Hour)),
+		CreationAcknowledged: timePtr(deleteTestBase.Add(-10 * time.Minute)),
+	})
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraDelete(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(300), requeue)
+	require.Eventually(t, func() bool {
+		return fi.destroyCallCount() == 1
+	}, 5*time.Second, 5*time.Millisecond, "destroy goroutine never launched")
+	assert.Equal(t, 1, fl.callCount("AckDeletion"))
+	assert.Equal(t, 1, fl.callCount("BuildInfra"))
+	assert.Equal(t, 2, fl.callCount("GetReconciliation"))
+
+	fi.releaseDestroy()
+	drainDeleteOps(t)
+	assert.Equal(t, 1, fl.callCount("ClearInventory"))
+	assert.Equal(t, 1, fl.callCount("PublishDeleteNotification"))
+}
+
+// TestHandleInfraDelete_FreshAckButCreateFailed_StillRequeues60 is a
+// behavior pin for hardening item 11: the cross-replica guard ignores
+// CreationFailed by design today, so a fresh CreationAcknowledged with
+// CreationFailed set and no CreationConfirmed still requeues at 60 seconds
+// without launching. A failed create may be retried by another replica at
+// any moment, so deleting underneath it is unsafe; making the guard treat
+// failed creates as deletable requires coordination with the provider
+// adapter owners. If this test starts failing, that contract changed.
+func TestHandleInfraDelete_FreshAckButCreateFailed_StillRequeues60(t *testing.T) {
+	restoreCfg := setLifecycleConfig(testLifecycleConfig())
+	t.Cleanup(restoreCfg)
+	clk := newFakeClock(deleteTestBase)
+	restoreClk := setLifecycleClock(clk)
+	t.Cleanup(restoreClk)
+
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		DeletionScheduled:    timePtr(deleteTestBase.Add(-time.Hour)),
+		CreationAcknowledged: timePtr(deleteTestBase.Add(-time.Minute)),
+		CreationFailed:       true,
+	})
+
+	requeue, err := HandleInfraDelete(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(60), requeue)
+	assert.Equal(t, 0, fl.callCount("AckDeletion"))
+	assert.Equal(t, 0, fl.callCount("BuildInfra"))
+	assert.Equal(t, int64(0), inFlightCount())
+}
+
+// TestHandleInfraDelete_AckedInventoryCleared_Confirms pins the confirmation
+// branch: with deletion already acknowledged, the handler re-fetches state
+// and reads inventory cleared from the latest snapshot's ResourceInventory,
+// then refreshes the ack, builds infra, runs post-deletion cleanup, confirms
+// deletion, and returns (0, nil) without launching a goroutine.
+func TestHandleInfraDelete_AckedInventoryCleared_Confirms(t *testing.T) {
+	// "{}" is one of the cleared inventory sentinels
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		DeletionScheduled:    timePtr(deleteTestBase.Add(-time.Hour)),
+		DeletionAcknowledged: timePtr(deleteTestBase.Add(-time.Minute)),
+		ResourceInventory:    jsonPtr("{}"),
+	})
+
+	requeue, err := HandleInfraDelete(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), requeue)
+	assert.Equal(t, 2, fl.callCount("GetReconciliation"))
+	assert.Equal(t, 1, fl.callCount("RefreshDeletionAck"))
+	assert.Equal(t, 1, fl.callCount("BuildInfra"))
+	assert.Equal(t, 1, fl.callCount("OnDeleteConfirmed"))
+	assert.Equal(t, 1, fl.callCount("ConfirmDeletion"))
+	assert.Equal(t, 0, fl.callCount("AckDeletion"))
+	assert.Equal(t, int64(0), inFlightCount())
+}
+
+// TestHandleInfraDelete_OnDeleteConfirmedError_Requeue60 pins the cleanup
+// retry branch: when post-deletion cleanup fails the handler requeues at 60
+// seconds and does not confirm deletion, so the next reconciliation retries
+// the cleanup.
+func TestHandleInfraDelete_OnDeleteConfirmedError_Requeue60(t *testing.T) {
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		DeletionScheduled:    timePtr(deleteTestBase.Add(-time.Hour)),
+		DeletionAcknowledged: timePtr(deleteTestBase.Add(-time.Minute)),
+		ResourceInventory:    jsonPtr("{}"),
+	})
+	fl.setErr("OnDeleteConfirmed", errors.New("injected: post-deletion cleanup failure"))
+
+	requeue, err := HandleInfraDelete(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(60), requeue)
+	assert.Equal(t, 1, fl.callCount("RefreshDeletionAck"))
+	assert.Equal(t, 1, fl.callCount("OnDeleteConfirmed"))
+	assert.Equal(t, 0, fl.callCount("ConfirmDeletion"))
+	assert.Equal(t, int64(0), inFlightCount())
+}
+
+// TestHandleInfraDelete_AckedInventoryNotCleared_FreshAck_Requeue60 pins the
+// wait branch: deletion acknowledged, inventory still holds resources, and
+// the ack is fresh, meaning a destroy is presumed in progress elsewhere, so
+// the handler requeues at 60 seconds without re-acking or launching.
+func TestHandleInfraDelete_AckedInventoryNotCleared_FreshAck_Requeue60(t *testing.T) {
+	restoreCfg := setLifecycleConfig(testLifecycleConfig())
+	t.Cleanup(restoreCfg)
+	clk := newFakeClock(deleteTestBase)
+	restoreClk := setLifecycleClock(clk)
+	t.Cleanup(restoreClk)
+
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		DeletionScheduled:    timePtr(deleteTestBase.Add(-time.Hour)),
+		DeletionAcknowledged: timePtr(deleteTestBase.Add(-time.Minute)),
+		ResourceInventory:    validStackState(),
+	})
+
+	requeue, err := HandleInfraDelete(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(60), requeue)
+	assert.Equal(t, 2, fl.callCount("GetReconciliation"))
+	assert.Equal(t, 0, fl.callCount("RefreshDeletionAck"))
+	assert.Equal(t, 0, fl.callCount("AckDeletion"))
+	assert.Equal(t, 0, fl.callCount("BuildInfra"))
+	assert.Equal(t, int64(0), inFlightCount())
+}
+
+// TestHandleInfraDelete_AckedInventoryNotCleared_StaleAck_Relaunches pins
+// the recovery branch: deletion acknowledged, inventory still holds
+// resources, but the ack has gone stale, so the prior destroy is presumed
+// interrupted. The handler re-acks, builds infra, restores the surviving
+// inventory into the stack, and re-launches the destroy goroutine.
+func TestHandleInfraDelete_AckedInventoryNotCleared_StaleAck_Relaunches(t *testing.T) {
+	cfg := testLifecycleConfig()
+	cfg.SemaphoreCapacity = 1
+	restoreCfg := setLifecycleConfig(cfg)
+	t.Cleanup(restoreCfg)
+	clk := newFakeClock(deleteTestBase)
+	restoreClk := setLifecycleClock(clk)
+	t.Cleanup(restoreClk)
+
+	fi := newFakeInfra()
+	fi.setDestroy(infraBlock, nil)
+	inventory := validStackState()
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		DeletionScheduled:    timePtr(deleteTestBase.Add(-time.Hour)),
+		DeletionAcknowledged: timePtr(deleteTestBase.Add(-10 * time.Minute)),
+		ResourceInventory:    inventory,
+	})
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraDelete(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(300), requeue)
+	require.Eventually(t, func() bool {
+		return fi.destroyCallCount() == 1
+	}, 5*time.Second, 5*time.Millisecond, "destroy goroutine never launched")
+	assert.Equal(t, 1, fl.callCount("AckDeletion"))
+	assert.Equal(t, 1, fl.callCount("BuildInfra"))
+	assert.Equal(t, 3, fl.callCount("GetReconciliation"))
+
+	// state restoration happens before destroy, so it is settled by now
+	assert.Equal(t, 1, fi.setStackStateCallCount())
+	assert.Equal(t, inventory, fi.lastRestoredState())
+
+	fi.releaseDestroy()
+	drainDeleteOps(t)
+	assert.Equal(t, 1, fl.callCount("ClearInventory"))
+	assert.Equal(t, 1, fl.callCount("PublishDeleteNotification"))
+}
+
+// TestHandleInfraDelete_NewRequest_AcksBuildsLaunches pins the happy-path
+// launch branch: deletion scheduled with no prior acknowledgement means a
+// brand new delete request, so the handler acks deletion, builds infra,
+// launches the destroy goroutine, and returns the 300 second requeue.
+func TestHandleInfraDelete_NewRequest_AcksBuildsLaunches(t *testing.T) {
+	cfg := testLifecycleConfig()
+	cfg.SemaphoreCapacity = 1
+	restoreCfg := setLifecycleConfig(cfg)
+	t.Cleanup(restoreCfg)
+
+	fi := newFakeInfra()
+	fi.setDestroy(infraBlock, nil)
+	fl := newFakeLifecycle(&ReconciliationSnapshot{
+		DeletionScheduled: timePtr(deleteTestBase.Add(-time.Minute)),
+	})
+	fl.setInfra(fi)
+
+	requeue, err := HandleInfraDelete(fl, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(300), requeue)
+	require.Eventually(t, func() bool {
+		return fi.destroyCallCount() == 1
+	}, 5*time.Second, 5*time.Millisecond, "destroy goroutine never launched")
+	assert.Equal(t, 1, fl.callCount("AckDeletion"))
+	assert.Equal(t, 1, fl.callCount("BuildInfra"))
+	assert.Equal(t, 2, fl.callCount("GetReconciliation"))
+
+	// nil inventory means nothing to restore before the destroy
+	assert.Equal(t, 0, fi.setStackStateCallCount())
+
+	fi.releaseDestroy()
+	drainDeleteOps(t)
+	assert.Equal(t, 1, fl.callCount("ClearInventory"))
+	assert.Equal(t, 1, fl.callCount("PublishDeleteNotification"))
+}

--- a/internal/provider/helpers_test.go
+++ b/internal/provider/helpers_test.go
@@ -1,0 +1,280 @@
+package provider
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/datatypes"
+)
+
+// testLifecycleConfig returns a LifecycleConfig with production-default
+// stale ack threshold and semaphore capacity but test-friendly persist
+// settings, for per-test overrides via setLifecycleConfig.
+func testLifecycleConfig() LifecycleConfig {
+	return LifecycleConfig{
+		StaleAckThreshold: 240 * time.Second,
+		RefreshInterval:   time.Hour,
+		SemaphoreCapacity: 5,
+		PersistRetries:    1,
+		PersistRetryDelay: time.Millisecond,
+	}
+}
+
+// TestCheckStaleAck_Boundary pins the strict greater-than comparison in
+// stale ack detection: an ack aged exactly at the threshold is not yet
+// stale, only ages strictly beyond the threshold are.
+func TestCheckStaleAck_Boundary(t *testing.T) {
+	clk := newFakeClock(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	restoreClock := setLifecycleClock(clk)
+	t.Cleanup(restoreClock)
+
+	restoreConfig := setLifecycleConfig(testLifecycleConfig())
+	t.Cleanup(restoreConfig)
+
+	cases := []struct {
+		name      string
+		ackAge    time.Duration
+		wantStale bool
+	}{
+		{
+			name:      "ack aged 239s is not stale",
+			ackAge:    239 * time.Second,
+			wantStale: false,
+		},
+		{
+			name:      "ack aged exactly 240s is not stale",
+			ackAge:    240 * time.Second,
+			wantStale: false,
+		},
+		{
+			name:      "ack aged 240s plus 100ms is stale",
+			ackAge:    240*time.Second + 100*time.Millisecond,
+			wantStale: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ackTimestamp := clk.Now().Add(-tc.ackAge)
+			assert.Equal(t, tc.wantStale, checkStaleAck(ackTimestamp))
+		})
+	}
+}
+
+// TestVerifyState_NilEmptyInvalid pins the three early-reject branches
+// of state verification: nil pointer, zero-length bytes, and bytes that
+// fail JSON parsing.
+func TestVerifyState_NilEmptyInvalid(t *testing.T) {
+	cases := []struct {
+		name       string
+		state      *datatypes.JSON
+		wantErrSub string
+	}{
+		{
+			name:       "nil state is rejected",
+			state:      nil,
+			wantErrSub: "state is nil",
+		},
+		{
+			name:       "empty state is rejected",
+			state:      jsonPtr(""),
+			wantErrSub: "state is empty",
+		},
+		{
+			name:       "non-JSON bytes are rejected",
+			state:      jsonPtr("this is not json {{"),
+			wantErrSub: "not valid JSON",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyState(tc.state, newTestLogger())
+			assert.ErrorContains(t, err, tc.wantErrSub)
+		})
+	}
+}
+
+// TestVerifyState_CheckpointFormat_CountsResources pins that resources
+// nested under checkpoint.latest.resources are counted and a non-empty
+// list passes verification.
+func TestVerifyState_CheckpointFormat_CountsResources(t *testing.T) {
+	state := jsonPtr(`{"checkpoint":{"latest":{"resources":[{"urn":"a"},{"urn":"b"},{"urn":"c"}]}}}`)
+	assert.NoError(t, verifyState(state, newTestLogger()))
+}
+
+// TestVerifyState_DeploymentFormat pins that resources under
+// deployment.resources are counted and a non-empty list passes
+// verification.
+func TestVerifyState_DeploymentFormat(t *testing.T) {
+	state := jsonPtr(`{"deployment":{"resources":[{"urn":"a"}]}}`)
+	assert.NoError(t, verifyState(state, newTestLogger()))
+}
+
+// TestVerifyState_NoResources pins the no-resources rejection branch:
+// valid JSON whose checkpoint and deployment resource lists are empty
+// or missing fails verification.
+func TestVerifyState_NoResources(t *testing.T) {
+	cases := []struct {
+		name  string
+		state *datatypes.JSON
+	}{
+		{
+			name:  "both formats missing",
+			state: jsonPtr(`{"other":"content"}`),
+		},
+		{
+			name:  "checkpoint format with empty resources",
+			state: jsonPtr(`{"checkpoint":{"latest":{"resources":[]}}}`),
+		},
+		{
+			name:  "deployment format with empty resources",
+			state: jsonPtr(`{"deployment":{"resources":[]}}`),
+		},
+		{
+			name:  "both formats present with empty resources",
+			state: jsonPtr(`{"checkpoint":{"latest":{"resources":[]}},"deployment":{"resources":[]}}`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyState(tc.state, newTestLogger())
+			assert.ErrorContains(t, err, "state contains no resources")
+		})
+	}
+}
+
+// TestInventoryCleared_Table pins which inventory values count as
+// cleared: nil, zero-length, empty object, and JSON null are cleared;
+// an object with content is not.
+func TestInventoryCleared_Table(t *testing.T) {
+	cases := []struct {
+		name      string
+		inventory *datatypes.JSON
+		want      bool
+	}{
+		{
+			name:      "nil inventory is cleared",
+			inventory: nil,
+			want:      true,
+		},
+		{
+			name:      "zero-length inventory is cleared",
+			inventory: jsonPtr(""),
+			want:      true,
+		},
+		{
+			name:      "empty object inventory is cleared",
+			inventory: jsonPtr("{}"),
+			want:      true,
+		},
+		{
+			name:      "json null inventory is cleared",
+			inventory: jsonPtr("null"),
+			want:      true,
+		},
+		{
+			name:      "populated inventory is not cleared",
+			inventory: validStackState(),
+			want:      false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, inventoryCleared(tc.inventory))
+		})
+	}
+}
+
+// TestHasExistingState_Table pins which state values count as restorable
+// existing state: nil, zero-length, empty object, and JSON null do not;
+// an object with content does.
+func TestHasExistingState_Table(t *testing.T) {
+	cases := []struct {
+		name  string
+		state *datatypes.JSON
+		want  bool
+	}{
+		{
+			name:  "nil state is not existing state",
+			state: nil,
+			want:  false,
+		},
+		{
+			name:  "zero-length state is not existing state",
+			state: jsonPtr(""),
+			want:  false,
+		},
+		{
+			name:  "empty object state is not existing state",
+			state: jsonPtr("{}"),
+			want:  false,
+		},
+		{
+			name:  "json null state is not existing state",
+			state: jsonPtr("null"),
+			want:  false,
+		},
+		{
+			name:  "populated state is existing state",
+			state: validStackState(),
+			want:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hasExistingState(tc.state))
+		})
+	}
+}
+
+// TestPersistFailure_SucceedsFirstTry pins the immediate-return branch:
+// a persist function that succeeds on its first call is invoked exactly
+// once and the retry delay is never waited out.
+func TestPersistFailure_SucceedsFirstTry(t *testing.T) {
+	config := testLifecycleConfig()
+	config.PersistRetries = 3
+	config.PersistRetryDelay = 10 * time.Second
+	restore := setLifecycleConfig(config)
+	t.Cleanup(restore)
+
+	calls := 0
+	persist := func() error {
+		calls++
+		return nil
+	}
+
+	start := time.Now()
+	persistFailure(persist, newTestLogger())
+	elapsed := time.Since(start)
+
+	assert.Equal(t, 1, calls)
+	assert.Less(t, elapsed, time.Second,
+		"first-try success must return without waiting the retry delay")
+}
+
+// TestPersistFailure_Exhaustion pins the retry-exhaustion branch: a
+// persist function that always errors is retried up to the configured
+// count and the call returns normally afterward.
+func TestPersistFailure_Exhaustion(t *testing.T) {
+	config := testLifecycleConfig()
+	config.PersistRetries = 3
+	config.PersistRetryDelay = time.Millisecond
+	restore := setLifecycleConfig(config)
+	t.Cleanup(restore)
+
+	calls := 0
+	persist := func() error {
+		calls++
+		return errors.New("persist always fails")
+	}
+
+	persistFailure(persist, newTestLogger())
+
+	assert.Equal(t, 3, calls)
+}

--- a/internal/provider/infra_lifecycle.go
+++ b/internal/provider/infra_lifecycle.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -13,13 +15,105 @@ import (
 	"gorm.io/datatypes"
 )
 
-// staleAckDurationSeconds is the threshold after which an acknowledgement
-// timestamp is considered stale, indicating the operation was interrupted.
-const staleAckDurationSeconds = 240
+// LifecycleConfig holds the tunable parameters of the infra
+// lifecycle state machine. Production uses the defaults; tests
+// override via setLifecycleConfig.
+type LifecycleConfig struct {
+	StaleAckThreshold time.Duration
+	RefreshInterval   time.Duration
+	SemaphoreCapacity int
+	PersistRetries    int
+	PersistRetryDelay time.Duration
+}
+
+// defaultLifecycleConfig is the production configuration.
+var defaultLifecycleConfig = LifecycleConfig{
+	StaleAckThreshold: 240 * time.Second,
+	RefreshInterval:   60 * time.Second,
+	SemaphoreCapacity: 5,
+	PersistRetries:    30,
+	PersistRetryDelay: 10 * time.Second,
+}
+
+// lifecycleMu guards lifecycleConfig and infraSemaphore. Production sets
+// them once at init and only reads, so the read lock is uncontended;
+// tests swap them via setLifecycleConfig, and the lock keeps that swap
+// from racing the background goroutines that read the values.
+var lifecycleMu sync.RWMutex
+
+// lifecycleConfig is the active configuration read by the lifecycle
+// state machine.
+var lifecycleConfig = defaultLifecycleConfig
 
 // infraSemaphore limits concurrent infrastructure operations to prevent OOM
 // from too many simultaneous deployments.
 var infraSemaphore = make(chan struct{}, 5)
+
+// currentConfig returns the active lifecycle configuration.
+func currentConfig() LifecycleConfig {
+	lifecycleMu.RLock()
+	defer lifecycleMu.RUnlock()
+	return lifecycleConfig
+}
+
+// currentSemaphore returns the active semaphore channel. Callers that
+// both acquire and release a slot must capture this once and reuse it,
+// so the release lands on the same channel even if a test swaps the
+// global in between.
+func currentSemaphore() chan struct{} {
+	lifecycleMu.RLock()
+	defer lifecycleMu.RUnlock()
+	return infraSemaphore
+}
+
+// setLifecycleConfig swaps the lifecycle tunables and re-creates the
+// semaphore channel at the new capacity. Returns a restore func for
+// t.Cleanup. Only for tests.
+func setLifecycleConfig(c LifecycleConfig) (restore func()) {
+	lifecycleMu.Lock()
+	oldConfig := lifecycleConfig
+	oldSemaphore := infraSemaphore
+	lifecycleConfig = c
+	infraSemaphore = make(chan struct{}, c.SemaphoreCapacity)
+	lifecycleMu.Unlock()
+	return func() {
+		lifecycleMu.Lock()
+		lifecycleConfig = oldConfig
+		infraSemaphore = oldSemaphore
+		lifecycleMu.Unlock()
+	}
+}
+
+// Clock abstracts wall-clock reads for stale-ack logic so tests can
+// inject a fixed or advanceable time.
+type Clock interface{ Now() time.Time }
+
+// realClock implements Clock using the system wall clock.
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+// lifecycleClock is the clock used for stale-ack checks.
+var lifecycleClock Clock = realClock{}
+
+// setLifecycleClock swaps the lifecycle clock. Returns a restore func
+// for t.Cleanup. Only for tests; not concurrency-safe, call before
+// spawning goroutines.
+func setLifecycleClock(c Clock) (restore func()) {
+	oldClock := lifecycleClock
+	lifecycleClock = c
+	return func() {
+		lifecycleClock = oldClock
+	}
+}
+
+// inFlightOps counts infrastructure create and delete operations
+// currently executing in background goroutines.
+var inFlightOps int64
+
+// inFlightCount returns the number of in-flight infrastructure
+// operations. Only for tests.
+func inFlightCount() int64 { return atomic.LoadInt64(&inFlightOps) }
 
 // ReconciliationSnapshot captures the reconciliation timestamps and resource
 // inventory for a provider instance at a point in time. This decouples the
@@ -359,17 +453,19 @@ type infraConfig struct {
 // checkStaleAck returns true if the given acknowledgement timestamp has gone
 // stale, indicating the operation was interrupted (e.g. pod restart).
 func checkStaleAck(ackTimestamp time.Time) bool {
-	duration := time.Now().UTC().Sub(ackTimestamp)
-	return duration.Seconds() > staleAckDurationSeconds
+	duration := lifecycleClock.Now().UTC().Sub(ackTimestamp)
+	return duration > currentConfig().StaleAckThreshold
 }
 
 // launchInfraCreate acquires the concurrency semaphore, then launches
 // executeInfraCreate in a background goroutine. Returns a requeue delay
 // for the reconciler.
 func launchInfraCreate(config infraConfig) (int64, error) {
-	// acquire infrastructure concurrency semaphore
+	// acquire infrastructure concurrency semaphore; capture the channel
+	// once so the release lands on the same channel
+	sem := currentSemaphore()
 	select {
-	case infraSemaphore <- struct{}{}:
+	case sem <- struct{}{}:
 		// acquired slot
 	default:
 		config.Log.Info("infrastructure worker pool full, requeuing")
@@ -378,7 +474,7 @@ func launchInfraCreate(config infraConfig) (int64, error) {
 
 	// launch creation in background goroutine
 	go func() {
-		defer func() { <-infraSemaphore }()
+		defer func() { <-sem }()
 		defer func() {
 			if r := recover(); r != nil {
 				config.Log.Error(fmt.Errorf("panic: %v", r), "recovered panic in infrastructure create goroutine")
@@ -395,9 +491,11 @@ func launchInfraCreate(config infraConfig) (int64, error) {
 // executeInfraDelete in a background goroutine. Returns a requeue delay
 // for the reconciler.
 func launchInfraDelete(config infraConfig) (int64, error) {
-	// acquire infrastructure concurrency semaphore
+	// acquire infrastructure concurrency semaphore; capture the channel
+	// once so the release lands on the same channel
+	sem := currentSemaphore()
 	select {
-	case infraSemaphore <- struct{}{}:
+	case sem <- struct{}{}:
 		// acquired slot
 	default:
 		config.Log.Info("infrastructure worker pool full, requeuing")
@@ -406,7 +504,7 @@ func launchInfraDelete(config infraConfig) (int64, error) {
 
 	// launch deletion in background goroutine
 	go func() {
-		defer func() { <-infraSemaphore }()
+		defer func() { <-sem }()
 		defer func() {
 			if r := recover(); r != nil {
 				config.Log.Error(fmt.Errorf("panic: %v", r), "recovered panic in infrastructure delete goroutine")
@@ -422,6 +520,10 @@ func launchInfraDelete(config infraConfig) (int64, error) {
 // goroutine. It handles state restoration, optional streaming for providers
 // that support it, and captures final state on success or failure.
 func executeInfraCreate(config infraConfig) {
+	// track in-flight operations for observability in tests
+	atomic.AddInt64(&inFlightOps, 1)
+	defer atomic.AddInt64(&inFlightOps, -1)
+
 	// refresh the creation acknowledgement until this function returns
 	quitAck := make(chan bool, 1)
 	go refreshAck(config.Callbacks.RefreshAck, quitAck, config.Log)
@@ -514,6 +616,10 @@ func executeInfraCreate(config infraConfig) {
 // goroutine. It handles state restoration, optional refresh for providers
 // that support it, and captures updated state on failure.
 func executeInfraDelete(config infraConfig) {
+	// track in-flight operations for observability in tests
+	atomic.AddInt64(&inFlightOps, 1)
+	defer atomic.AddInt64(&inFlightOps, -1)
+
 	// refresh the deletion acknowledgement until this function returns
 	quitAck := make(chan bool, 1)
 	go refreshAck(config.Callbacks.RefreshAck, quitAck, config.Log)
@@ -654,9 +760,9 @@ func streamState(
 	}
 }
 
-// refreshAck calls the provided refresh function every 60 seconds until told
-// to quit, preventing stale acknowledgement detection from re-launching the
-// operation while it is still running.
+// refreshAck calls the provided refresh function on the configured refresh
+// interval until told to quit, preventing stale acknowledgement detection
+// from re-launching the operation while it is still running.
 func refreshAck(
 	refresh func() error,
 	quitChan chan bool,
@@ -666,7 +772,7 @@ func refreshAck(
 		select {
 		case <-quitChan:
 			return
-		case <-time.After(60 * time.Second):
+		case <-time.After(currentConfig().RefreshInterval):
 			if err := refresh(); err != nil {
 				log.Error(err, "failed to refresh acknowledged timestamp")
 			}
@@ -675,19 +781,20 @@ func refreshAck(
 }
 
 // persistFailure calls the provided persist function to mark the operation as
-// failed. If the call fails, it is retried every 10 seconds up to 30 times
-// (5 minutes). After exhausting retries, the goroutine returns and stale ack
-// detection will recover the operation.
+// failed. If the call fails, it is retried on the configured delay up to the
+// configured retry count. After exhausting retries, the goroutine returns and
+// stale ack detection will recover the operation.
 func persistFailure(
 	persist func() error,
 	log *logr.Logger,
 ) {
-	const maxRetries = 30
+	cfg := currentConfig()
+	maxRetries := cfg.PersistRetries
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if err := persist(); err != nil {
 			log.Error(err, "failed to persist creation failure - retrying in 10 sec",
 				"attempt", attempt+1, "maxRetries", maxRetries)
-			time.Sleep(time.Second * 10)
+			time.Sleep(cfg.PersistRetryDelay)
 			continue
 		}
 		return

--- a/internal/provider/pulumi_workspace.go
+++ b/internal/provider/pulumi_workspace.go
@@ -15,8 +15,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	yaml "sigs.k8s.io/yaml"
 	"gorm.io/datatypes"
+	yaml "sigs.k8s.io/yaml"
 
 	util "github.com/threeport/threeport/pkg/util/v0"
 )
@@ -42,10 +42,44 @@ type PulumiWorkspace struct {
 	// stateDir is the path to the Pulumi state directory on disk.
 	stateDir string
 
+	// stateDirRoot is an optional override for the root directory under
+	// which the per-instance state dir is built. When empty, the default
+	// runtime state dir is used.
+	stateDirRoot string
+
 	// Logger enables structured logging for Pulumi operations.
 	// When nil, ProgressStreams(os.Stdout) is used (CLI path).
 	// When set, EventStreams is used with structured logr output (controller path).
 	Logger *logr.Logger
+}
+
+// PulumiWorkspaceOption configures a PulumiWorkspace created by
+// NewPulumiWorkspace.
+type PulumiWorkspaceOption func(*PulumiWorkspace)
+
+// WithStateDirRoot overrides the root directory under which the
+// workspace builds its per-instance state dir. Tests pass a temp
+// dir; the machine provider passes its own root.
+func WithStateDirRoot(root string) PulumiWorkspaceOption {
+	return func(w *PulumiWorkspace) {
+		w.stateDirRoot = root
+	}
+}
+
+// NewPulumiWorkspace returns a workspace for the named runtime
+// instance under the given pulumi project. Both values are
+// required: the state file path resolves to
+// stateDir/.pulumi/stacks/<project>/<name>.json, so an empty
+// project produces a malformed path.
+func NewPulumiWorkspace(name, project string, opts ...PulumiWorkspaceOption) *PulumiWorkspace {
+	w := &PulumiWorkspace{
+		RuntimeInstanceName: name,
+		ProjectName:         project,
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+	return w
 }
 
 // logInfo logs an informational message using the structured logger if
@@ -173,6 +207,12 @@ func (w *PulumiWorkspace) SetStackState(state *datatypes.JSON) error {
 
 // GetStateFilePath returns the path to the Pulumi state JSON file on disk.
 func (w *PulumiWorkspace) GetStateFilePath() (string, error) {
+	// guard against empty instance names so two unnamed instances cannot
+	// collide on the same state file
+	if w.RuntimeInstanceName == "" {
+		return "", fmt.Errorf("runtime instance name is empty; refusing to build state file path")
+	}
+
 	if err := w.setStateDir(); err != nil {
 		return "", fmt.Errorf("failed to set state directory: %w", err)
 	}
@@ -486,11 +526,17 @@ func (w *PulumiWorkspace) getEnvVars() (map[string]string, error) {
 
 // setStateDir sets the state directory for the Pulumi stack.
 func (w *PulumiWorkspace) setStateDir() error {
-	dir, err := GetPulumiRuntimeStateDir(w.RuntimeInstanceName)
-	if err != nil {
-		return err
+	// resolve the state dir from the injected root when set, otherwise
+	// fall back to the default runtime state dir
+	if w.stateDirRoot != "" {
+		w.stateDir = filepath.Join(w.stateDirRoot, w.RuntimeInstanceName)
+	} else {
+		dir, err := GetPulumiRuntimeStateDir(w.RuntimeInstanceName)
+		if err != nil {
+			return err
+		}
+		w.stateDir = dir
 	}
-	w.stateDir = dir
 	if err := os.MkdirAll(w.stateDir, 0755); err != nil {
 		return fmt.Errorf("failed to create state directory: %w", err)
 	}

--- a/internal/provider/pulumi_workspace_test.go
+++ b/internal/provider/pulumi_workspace_test.go
@@ -1,0 +1,261 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// requirePulumiCLI skips the test when the pulumi CLI is not on PATH,
+// since every workspace and stack operation shells out to it. It also
+// redirects the home dir to a temp dir so the pulumi home directory
+// created during workspace setup never touches the real home dir, and
+// disables the CLI update check to avoid network calls.
+func requirePulumiCLI(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("pulumi"); err != nil {
+		t.Skip("pulumi CLI not found on PATH; skipping test that needs a real pulumi backend")
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PULUMI_SKIP_UPDATE_CHECK", "true")
+}
+
+// checkpointState returns a minimal checkpoint-format state JSON for the
+// given project and stack name. The top-level "checkpoint" key, and the
+// absence of a top-level "deployment" key, routes SetStackState() to the
+// direct file-write path. The marker lands in the resource URN so two
+// payloads for the same stack can be told apart byte-for-byte.
+func checkpointState(project, name, marker string) string {
+	return fmt.Sprintf(
+		`{"version":3,"checkpoint":{"stack":"organization/%s/%s","latest":{"manifest":{"time":"0001-01-01T00:00:00Z","magic":"","version":""},"resources":[{"urn":"urn:pulumi:%s::%s::pulumi:pulumi:Stack::%s","type":"pulumi:pulumi:Stack"}]}}}`,
+		project, name, name, project, marker,
+	)
+}
+
+// TestNewPulumiWorkspace_WithStateDirRoot pins the constructor seam: the
+// runtime instance name and project name are set from the arguments, the
+// state dir root option makes the state dir resolve to <root>/<name>, and
+// the state file path lands under the injected root at
+// .pulumi/stacks/<project>/<name>.json.
+func TestNewPulumiWorkspace_WithStateDirRoot(t *testing.T) {
+	root := t.TempDir()
+	w := NewPulumiWorkspace("instance-a", "oke", WithStateDirRoot(root))
+
+	assert.Equal(t, "instance-a", w.RuntimeInstanceName)
+	assert.Equal(t, "oke", w.ProjectName)
+	assert.Equal(t, root, w.stateDirRoot)
+
+	path, err := w.GetStateFilePath()
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		filepath.Join(root, "instance-a", ".pulumi", "stacks", "oke", "instance-a.json"),
+		path,
+	)
+
+	// resolving the path builds <root>/<name> and creates it on disk
+	assert.Equal(t, filepath.Join(root, "instance-a"), w.stateDir)
+	info, err := os.Stat(w.stateDir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+// TestNewPulumiWorkspace_DefaultRoot pins the fallback branch of state dir
+// resolution: without the state dir root option, the state dir resolves
+// under the home-dir runtime state path. The home dir is redirected to a
+// temp dir so the side-effecting mkdir never touches the real home dir;
+// the assertions check the prefix and suffix structure of the path.
+func TestNewPulumiWorkspace_DefaultRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	w := NewPulumiWorkspace("instance-b", "eks")
+
+	path, err := w.GetStateFilePath()
+	require.NoError(t, err)
+
+	wantSuffix := filepath.Join(
+		".threeport", "pulumi-state", "instance-b",
+		".pulumi", "stacks", "eks", "instance-b.json",
+	)
+	assert.True(
+		t, strings.HasSuffix(path, wantSuffix),
+		"path %q should end with %q", path, wantSuffix,
+	)
+	assert.True(
+		t, strings.HasPrefix(path, home),
+		"path %q should be under the redirected home dir %q", path, home,
+	)
+
+	// the state dir was created under the redirected home dir, proving
+	// the default-root branch only ever touches the resolved home
+	info, err := os.Stat(filepath.Join(home, ".threeport", "pulumi-state", "instance-b"))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+// TestGetStateFilePath_EmptyName pins the empty-name guard added by the
+// seam: an empty runtime instance name returns an error refusing to build
+// the path, before any filesystem side effects, so two unnamed instances
+// can never collide on the same state file.
+func TestGetStateFilePath_EmptyName(t *testing.T) {
+	root := t.TempDir()
+	w := NewPulumiWorkspace("", "oke", WithStateDirRoot(root))
+
+	path, err := w.GetStateFilePath()
+	require.Error(t, err)
+	assert.Empty(t, path)
+	assert.Contains(t, err.Error(), "runtime instance name is empty")
+
+	// the guard fires before state dir creation, so the root stays empty
+	entries, err := os.ReadDir(root)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+// TestSetStackState_CheckpointRoundTrip pins the checkpoint-format branch
+// of state restoration: JSON with a top-level "checkpoint" key, and no
+// top-level "deployment" key, bypasses the backend import and is written
+// directly to the state file, landing on disk byte-identical and reading
+// back unchanged.
+func TestSetStackState_CheckpointRoundTrip(t *testing.T) {
+	requirePulumiCLI(t)
+
+	root := t.TempDir()
+	w := NewPulumiWorkspace("ckpt-instance", "ckptproj", WithStateDirRoot(root))
+
+	state := checkpointState("ckptproj", "ckpt-instance", "round-trip")
+	require.NoError(t, w.SetStackState(jsonPtr(state)))
+
+	path, err := w.GetStateFilePath()
+	require.NoError(t, err)
+	onDisk, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, state, string(onDisk), "checkpoint state must land on disk byte-identical")
+
+	readBack, err := w.ReadStateFile()
+	require.NoError(t, err)
+	require.NotNil(t, readBack)
+	assert.Equal(t, state, string(*readBack))
+}
+
+// TestSetStackState_AtomicTempThenRename pins the atomic temp-then-rename
+// write of the checkpoint branch in three parts. Success: the target holds
+// the content and no temp file remains. Temp-write failure: a directory
+// occupying the temp path makes the temp write fail, the temp-write error
+// surfaces, and the previously written state is left intact, which is the
+// atomicity guarantee. Rename failure: the implementation exposes no
+// injectable rename failure, so the test simulates one by pre-creating the
+// target as a directory. Reading the live code, the simulation is expected
+// to be intercepted before the rename: the backend stack upsert fails
+// first because the file backend treats a directory as a missing blob and
+// then cannot write its own snapshot over it, leaving the production
+// rename branch unreachable from outside. Because that interception cannot
+// be confirmed without a live backend run, the test pins the invariants
+// shared by both candidate failure points: an error surfaces, no temp file
+// survives (the rename branch removes its temp file on failure), and the
+// directory occupying the target is untouched.
+func TestSetStackState_AtomicTempThenRename(t *testing.T) {
+	requirePulumiCLI(t)
+
+	root := t.TempDir()
+	w := NewPulumiWorkspace("atomic-instance", "atomicproj", WithStateDirRoot(root))
+
+	// part 1: successful write goes temp-then-rename and leaves no temp file
+	first := checkpointState("atomicproj", "atomic-instance", "first")
+	require.NoError(t, w.SetStackState(jsonPtr(first)))
+
+	path, err := w.GetStateFilePath()
+	require.NoError(t, err)
+	onDisk, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, first, string(onDisk))
+	_, statErr := os.Stat(path + ".tmp")
+	assert.True(t, os.IsNotExist(statErr), "no temp file may remain after a successful write")
+
+	// part 2: occupy the temp path with a directory so the temp write
+	// fails; the error surfaces and the prior state survives untouched
+	require.NoError(t, os.Mkdir(path+".tmp", 0755))
+	second := checkpointState("atomicproj", "atomic-instance", "second")
+	err = w.SetStackState(jsonPtr(second))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write temporary state file")
+	onDisk, err = os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, first, string(onDisk), "failed temp write must leave the previous state intact")
+	require.NoError(t, os.Remove(path+".tmp"))
+}
+
+// TestSetStackState_ExportFormatRequiresBackend pins the export-format
+// branch of state restoration: JSON with a top-level "deployment" key is
+// routed through the backend stack import, which converts it to checkpoint
+// format on disk, and a subsequent state export returns deployment-format
+// JSON. This needs a real pulumi backend, so the test skips when the CLI
+// is unavailable.
+func TestSetStackState_ExportFormatRequiresBackend(t *testing.T) {
+	requirePulumiCLI(t)
+
+	root := t.TempDir()
+	w := NewPulumiWorkspace("export-instance", "exportproj", WithStateDirRoot(root))
+
+	exportState := `{"version":3,"deployment":{"manifest":{"time":"0001-01-01T00:00:00Z","magic":"","version":""}}}`
+	require.NoError(t, w.SetStackState(jsonPtr(exportState)))
+
+	// the import converts to the backend's checkpoint format on disk
+	onDisk, err := w.ReadStateFile()
+	require.NoError(t, err)
+	require.NotNil(t, onDisk)
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(*onDisk, &parsed))
+	assert.Contains(t, parsed, "checkpoint")
+	assert.NotContains(t, parsed, "deployment")
+
+	// round trip: exporting the state returns deployment-format JSON
+	stateJSON, err := w.GetStackState()
+	require.NoError(t, err)
+	require.NotNil(t, stateJSON)
+	var deployment apitype.UntypedDeployment
+	require.NoError(t, json.Unmarshal(*stateJSON, &deployment))
+	assert.Equal(t, 3, deployment.Version)
+	assert.NotNil(t, deployment.Deployment)
+}
+
+// TestPulumiWorkspace_ZeroValueStillWorks pins zero-value compatibility
+// for the embedder pattern: a workspace built as a plain struct literal
+// with only the name fields set, no constructor and no options, still
+// resolves the state file path through the home-dir fallback exactly as
+// before the seams. The home dir is redirected to a temp dir so the path
+// resolution side effects stay out of the real home dir.
+func TestPulumiWorkspace_ZeroValueStillWorks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	w := &PulumiWorkspace{
+		RuntimeInstanceName: "instance-z",
+		ProjectName:         "gke",
+	}
+
+	path, err := w.GetStateFilePath()
+	require.NoError(t, err)
+
+	wantSuffix := filepath.Join(
+		".threeport", "pulumi-state", "instance-z",
+		".pulumi", "stacks", "gke", "instance-z.json",
+	)
+	assert.True(
+		t, strings.HasSuffix(path, wantSuffix),
+		"path %q should end with %q", path, wantSuffix,
+	)
+	assert.True(
+		t, strings.HasPrefix(path, home),
+		"path %q should be under the redirected home dir %q", path, home,
+	)
+}

--- a/internal/provider/reconciler_loop_test.go
+++ b/internal/provider/reconciler_loop_test.go
@@ -1,0 +1,228 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// peakWatcher samples inFlightCount in a tight loop and records the
+// highest value seen, so a test can assert the semaphore cap was never
+// exceeded at any instant rather than only at the sampling points.
+type peakWatcher struct {
+	peak int64
+	stop chan struct{}
+	done chan struct{}
+}
+
+func startPeakWatcher() *peakWatcher {
+	w := &peakWatcher{stop: make(chan struct{}), done: make(chan struct{})}
+	go func() {
+		defer close(w.done)
+		for {
+			select {
+			case <-w.stop:
+				return
+			default:
+				cur := inFlightCount()
+				for {
+					old := atomic.LoadInt64(&w.peak)
+					if cur <= old || atomic.CompareAndSwapInt64(&w.peak, old, cur) {
+						break
+					}
+				}
+			}
+		}
+	}()
+	return w
+}
+
+func (w *peakWatcher) stopAndPeak() int64 {
+	close(w.stop)
+	<-w.done
+	return atomic.LoadInt64(&w.peak)
+}
+
+// waitForInFlightZero polls until no infra operation is executing or the
+// deadline passes.
+func waitForInFlightZero(t *testing.T, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if inFlightCount() == 0 {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("in-flight operations did not drain to zero within %s (still %d)", within, inFlightCount())
+}
+
+// TestReconcilerLoop_2000Instances_SemaphoreCapped is the headline scale
+// test. It models the reconciler requeue loop: the semaphore acquire is
+// non-blocking, so a call when the pool is full returns (30, nil) without
+// launching. Blocking deploys hold every slot so the cap is observable;
+// the watcher proves the count of concurrently-executing operations never
+// exceeds the injected capacity no matter how hard the loop drives.
+func TestReconcilerLoop_2000Instances_SemaphoreCapped(t *testing.T) {
+	const (
+		n = 2000
+		k = 5
+	)
+	configureSemaphoreTest(t, k)
+
+	fis := make([]*fakeInfra, n)
+	fls := make([]*fakeLifecycle, n)
+	for i := range fis {
+		fis[i] = newFakeInfra()
+		fis[i].setDeploy(infraBlock, nil)
+		fls[i] = newFakeLifecycle()
+		fls[i].setInfra(fis[i])
+	}
+	// release before the drain cleanup runs (cleanups are LIFO, and
+	// configureSemaphoreTest registered the drain wait first)
+	t.Cleanup(func() {
+		for _, fi := range fis {
+			fi.releaseDeploy()
+		}
+	})
+
+	watcher := startPeakWatcher()
+	log := newTestLogger()
+
+	// drive several full passes over every instance; with blocking
+	// deploys only k slots ever fill and the rest requeue at 30
+	for pass := 0; pass < 5; pass++ {
+		for i := 0; i < n; i++ {
+			requeue, err := HandleInfraCreate(fls[i], log)
+			require.NoError(t, err)
+			// a launched instance requeues at 120; a pool-full instance
+			// at 30; never anything else on this path
+			require.Contains(t, []int64{30, 120}, requeue)
+		}
+	}
+
+	// the k blocked deploys should now hold every slot
+	require.Eventually(t, func() bool { return inFlightCount() == int64(k) }, 5*time.Second, time.Millisecond,
+		"expected exactly %d blocked operations, got %d", k, inFlightCount())
+
+	peak := watcher.stopAndPeak()
+	assert.LessOrEqual(t, peak, int64(k), "concurrently executing operations must never exceed the semaphore capacity")
+	assert.Equal(t, int64(k), peak, "with blocking deploys the pool should saturate at the capacity")
+
+	// release and confirm the pool drains back to zero
+	for _, fi := range fis {
+		fi.releaseDeploy()
+	}
+	waitForInFlightZero(t, 10*time.Second)
+}
+
+// TestReconcilerLoop_2000CreateAndDelete_Mixed drives 1000 create and 1000
+// delete launches interleaved under a small pool with fast-succeeding
+// operations. It proves the cap holds under sustained mixed churn and that
+// the loop never deadlocks, exercised under the race detector.
+func TestReconcilerLoop_2000CreateAndDelete_Mixed(t *testing.T) {
+	const (
+		creates = 1000
+		deletes = 1000
+		k       = 25
+	)
+	configureSemaphoreTest(t, k)
+
+	createFls := make([]*fakeLifecycle, creates)
+	for i := range createFls {
+		fi := newFakeInfra()
+		fi.setDeploy(infraSucceed, nil)
+		fl := newFakeLifecycle()
+		fl.setInfra(fi)
+		createFls[i] = fl
+	}
+	deleteFls := make([]*fakeLifecycle, deletes)
+	for i := range deleteFls {
+		fi := newFakeInfra()
+		fi.setDestroy(infraSucceed, nil)
+		fl := newFakeLifecycle(&ReconciliationSnapshot{
+			DeletionScheduled: timePtr(deleteTestBase.Add(-time.Minute)),
+		})
+		fl.setInfra(fi)
+		deleteFls[i] = fl
+	}
+
+	watcher := startPeakWatcher()
+	log := newTestLogger()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for pass := 0; pass < 10; pass++ {
+			for i := 0; i < creates; i++ {
+				if _, err := HandleInfraCreate(createFls[i], log); err != nil {
+					t.Errorf("create handler errored: %v", err)
+					return
+				}
+				if _, err := HandleInfraDelete(deleteFls[i], log); err != nil {
+					t.Errorf("delete handler errored: %v", err)
+					return
+				}
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("mixed reconciler loop deadlocked or made no progress within 60s")
+	}
+
+	peak := watcher.stopAndPeak()
+	assert.LessOrEqual(t, peak, int64(k), "mixed create/delete churn must never exceed the semaphore capacity")
+
+	waitForInFlightZero(t, 10*time.Second)
+}
+
+// TestPerInstanceStateDirIsolation builds many workspaces through the
+// exported constructor with a shared temp root and asserts each resolves
+// to a distinct state file path, then writes to all of them concurrently
+// to prove the per-instance directories never collide. The writes go
+// straight to the resolved paths so the test needs no Pulumi backend; that
+// is the isolation invariant the machine provider depends on.
+func TestPerInstanceStateDirIsolation(t *testing.T) {
+	const n = 100
+	root := t.TempDir()
+
+	paths := make([]string, n)
+	seen := make(map[string]bool, n)
+	for i := 0; i < n; i++ {
+		w := NewPulumiWorkspace(fmt.Sprintf("inst-%d", i), "proj", WithStateDirRoot(root))
+		p, err := w.GetStateFilePath()
+		require.NoError(t, err)
+		require.False(t, seen[p], "state file path collided across instances: %s", p)
+		seen[p] = true
+		paths[i] = p
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			require.NoError(t, os.MkdirAll(filepath.Dir(paths[i]), 0o755))
+			content := fmt.Sprintf("state-for-inst-%d", i)
+			require.NoError(t, os.WriteFile(paths[i], []byte(content), 0o644))
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		got, err := os.ReadFile(paths[i])
+		require.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("state-for-inst-%d", i), string(got),
+			"each instance's state file must hold only its own content")
+	}
+}


### PR DESCRIPTION
This PR brings the shared internal/provider infrastructure lifecycle under unit and concurrency test, and adds a few small testability seams the tests need. It is additive and signature-preserving: InfraProvider keeps its zero-arg DeployInfra()/DestroyInfra(), and the handlers keep HandleInfraCreate(p, log)/HandleInfraDelete(p, log), so the existing gcp and oci adapter call sites compile unchanged and no other package is touched. That independence is the point: the test-hardening PRs in this series are meant to be reviewed in parallel without breaking a shared signature.

The seams. Lifecycle tuning (stale-ack threshold, refresh-ack interval, semaphore capacity, persist-failure retry count and delay) moves into a LifecycleConfig swapped in tests via setLifecycleConfig(); production keeps today's defaults exactly (semaphore 5, stale-ack 240s, refresh 60s, persist 30 times at 10s). A new exported NewPulumiWorkspace(name, project, ...opts) constructor with WithStateDirRoot() lets tests, and the future machine provider, point per-instance state at a temp dir instead of the real state root. An always-on atomic in-flight counter, read in tests via inFlightCount(), backs the scale assertion. A Clock seam (setLifecycleClock()) makes stale-ack timing deterministic in tests.

The headline scale test proves the invariant that matters for provisioning many machines at once: the semaphore acquire is non-blocking, so a full pool returns a requeue delay immediately and starts no goroutine. The test models the reconciler requeue loop driving 2000 instances and asserts peak concurrent executions never exceed the injected cap and that everything drains to baseline, clean under the race detector. It does not assert via runtime.NumGoroutine() and does not assume N callers yield N goroutines.

Two existing quirks are pinned with tests and flagged for discussion rather than changed here, since changing either is a behavior change that belongs in a coordinated follow-up: the create path returns an OnCreateConfirmed() error without persisting a create-failure, and the cross-replica delete guard has no CreationFailed term, so a freshly-acked-but-failed create blocks delete until the ack goes stale. One small guard is added: GetStateFilePath() now returns an error on an empty instance name instead of building a colliding path; this is unreachable in production, where the instance name is always set.

PR5 (feat-gce-machine-provider) consumes NewPulumiWorkspace()/WithStateDirRoot() and may branch from this branch while it is unmerged, so the branch is pushed early as a stable base.
