### PR TITLE
fix: customize docker image for helm-workload-controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,8 +109,9 @@ RUN apk add --no-cache wget unzip && \
 # ----- helm-dirs: create helm cache dirs; consumed by release-helm -----
 FROM mirror.gcr.io/library/alpine:3 AS helm-dirs
 
-# distroless has no shell to mkdir; create the tree here.
-RUN mkdir -p /var/helm/.cache/helm
+# distroless has no shell to mkdir; create both directories here so that
+# all Helm state lives under /var/helm (the single writable volume).
+RUN mkdir -p /var/helm/.cache/helm /var/helm/.local/share/helm
 
 # ----- pulumi-bin: download pulumi; consumed by release-pulumi -----
 FROM mirror.gcr.io/library/alpine:3 AS pulumi-bin
@@ -143,8 +144,10 @@ FROM release AS release-helm
 # ownership from the source stage, so it must be declared here.
 COPY --chown=65532:65532 --from=helm-dirs /var/helm /var/helm
 
-# point the helm CLI at the pre-created writable cache directory.
+# point helm at the pre-created writable directories so no path falls back
+# to $HOME, which may not exist or be writable in distroless.
 ENV HELM_CACHE_HOME=/var/helm/.cache/helm
+ENV HELM_DATA_HOME=/var/helm/.local/share/helm
 
 # ----- release-pulumi: release + pulumi CLI -----
 FROM release AS release-pulumi

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@
 # Targets:
 #   release            Distroless image with the compiled binary.
 #   release-terraform  release + terraform CLI.
+#   release-helm       release + helm cache directory (/var/helm).
 #   release-pulumi     release + pulumi CLI.
 #
 # Multi-arch builds use `--platform=linux/amd64,linux/arm64`;
@@ -105,6 +106,12 @@ RUN apk add --no-cache wget unzip && \
     unzip -o terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip -d /out && \
     rm terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip
 
+# ----- helm-dirs: create helm cache dirs; consumed by release-helm -----
+FROM mirror.gcr.io/library/alpine:3 AS helm-dirs
+
+# distroless has no shell to mkdir; create the tree here.
+RUN mkdir -p /var/helm/.cache/helm
+
 # ----- pulumi-bin: download pulumi; consumed by release-pulumi -----
 FROM mirror.gcr.io/library/alpine:3 AS pulumi-bin
 
@@ -128,6 +135,16 @@ FROM release AS release-terraform
 # layer the terraform binary (fetched by the terraform-bin stage above)
 # onto release at the standard PATH location.
 COPY --from=terraform-bin /out/terraform /usr/local/bin/terraform
+
+# ----- release-helm: release + helm cache directory -----
+FROM release AS release-helm
+
+# --chown sets ownership in the destination; COPY --from does not carry
+# ownership from the source stage, so it must be declared here.
+COPY --chown=65532:65532 --from=helm-dirs /var/helm /var/helm
+
+# point the helm CLI at the pre-created writable cache directory.
+ENV HELM_CACHE_HOME=/var/helm/.cache/helm
 
 # ----- release-pulumi: release + pulumi CLI -----
 FROM release AS release-pulumi

--- a/internal/helm-workload/v0_helm_workload_instance.go
+++ b/internal/helm-workload/v0_helm_workload_instance.go
@@ -180,7 +180,25 @@ func v0HelmWorkloadInstanceCreated(
 	}
 	_, err = resourceClient.Create(context.Background(), unstructured, metav1.CreateOptions{})
 	if err != nil {
-		return 0, fmt.Errorf("failed to create new ThreeportWorkload resource: %w", err)
+		if !kubeerr.IsAlreadyExists(err) {
+			return 0, fmt.Errorf("failed to create new ThreeportWorkload resource: %w", err)
+		}
+		// stale ThreeportWorkload from a previous install; replace it so the
+		// agent watches the correct set of resources for this install.
+		if err = resourceClient.Delete(
+			context.Background(),
+			threeportWorkloadName,
+			metav1.DeleteOptions{},
+		); err != nil {
+			return 0, fmt.Errorf("failed to delete stale ThreeportWorkload resource: %w", err)
+		}
+		if _, err = resourceClient.Create(
+			context.Background(),
+			unstructured,
+			metav1.CreateOptions{},
+		); err != nil {
+			return 0, fmt.Errorf("failed to recreate ThreeportWorkload resource: %w", err)
+		}
 	}
 
 	// clean up files written to disk

--- a/internal/helm-workload/v0_helm_workload_instance.go
+++ b/internal/helm-workload/v0_helm_workload_instance.go
@@ -185,19 +185,23 @@ func v0HelmWorkloadInstanceCreated(
 		}
 		// stale ThreeportWorkload from a previous install; replace it so the
 		// agent watches the correct set of resources for this install.
-		if err = resourceClient.Delete(
+		// Use Get+Update rather than Delete+Create to avoid a transient window
+		// where the resource is absent and the agent has nothing to watch.
+		existing, err := resourceClient.Get(
 			context.Background(),
 			threeportWorkloadName,
-			metav1.DeleteOptions{},
-		); err != nil {
-			return 0, fmt.Errorf("failed to delete stale ThreeportWorkload resource: %w", err)
+			metav1.GetOptions{},
+		)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get stale ThreeportWorkload resource: %w", err)
 		}
-		if _, err = resourceClient.Create(
+		unstructured.SetResourceVersion(existing.GetResourceVersion())
+		if _, err = resourceClient.Update(
 			context.Background(),
 			unstructured,
-			metav1.CreateOptions{},
+			metav1.UpdateOptions{},
 		); err != nil {
-			return 0, fmt.Errorf("failed to recreate ThreeportWorkload resource: %w", err)
+			return 0, fmt.Errorf("failed to update stale ThreeportWorkload resource: %w", err)
 		}
 	}
 

--- a/internal/kubernetes-workload/v0_kubernetes_workload_instance.go
+++ b/internal/kubernetes-workload/v0_kubernetes_workload_instance.go
@@ -221,7 +221,29 @@ func v0KubernetesWorkloadInstanceCreated(
 	}
 	_, err = resourceClient.Create(context.Background(), unstructured, metav1.CreateOptions{})
 	if err != nil {
-		return 0, fmt.Errorf("failed to create new ThreeportWorkload resource: %w", err)
+		if !kubeerr.IsAlreadyExists(err) {
+			return 0, fmt.Errorf("failed to create new ThreeportWorkload resource: %w", err)
+		}
+		// stale ThreeportWorkload from a previous install; replace it so the
+		// agent watches the correct set of resources for this install.
+		// Use Get+Update rather than Delete+Create to avoid a transient window
+		// where the resource is absent and the agent has nothing to watch.
+		existing, err := resourceClient.Get(
+			context.Background(),
+			threeportWorkloadName,
+			metav1.GetOptions{},
+		)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get stale ThreeportWorkload resource: %w", err)
+		}
+		unstructured.SetResourceVersion(existing.GetResourceVersion())
+		if _, err = resourceClient.Update(
+			context.Background(),
+			unstructured,
+			metav1.UpdateOptions{},
+		); err != nil {
+			return 0, fmt.Errorf("failed to update stale ThreeportWorkload resource: %w", err)
+		}
 	}
 
 	return 0, nil

--- a/magefiles/magefile_gen.go
+++ b/magefiles/magefile_gen.go
@@ -1277,7 +1277,7 @@ func (Build) helmWorkloadControllerImagePackage(
 	if err := util.BuildImage(
 		workingDir,
 		"Dockerfile",
-		"release",
+		"release-helm",
 		arch,
 		"helm-workload-controller",
 		"bin",
@@ -2584,10 +2584,22 @@ func (Dev) LoadImage(kindClusterName string, component string) error {
 
 	imageName := fmt.Sprintf("threeport-%s", component)
 
+	// components that require a non-standard Dockerfile target; all others use "release".
+	componentTargets := map[string]string{
+		"gcp-controller":           "release-pulumi",
+		"helm-workload-controller": "release-helm",
+		"oci-controller":           "release-pulumi",
+		"terraform-controller":     "release-terraform",
+	}
+	dockerfileTarget := "release"
+	if t, ok := componentTargets[component]; ok {
+		dockerfileTarget = t
+	}
+
 	if err := util.BuildImage(
 		workingDir,
 		"Dockerfile",
-		"release",
+		dockerfileTarget,
 		arch,
 		component,
 		"bin",

--- a/pkg/sdk/v0/gen/root/magefile.go
+++ b/pkg/sdk/v0/gen/root/magefile.go
@@ -21,10 +21,11 @@ import (
 // name of the generated package-only function that the AllImages* tasks
 // call to skip redundant compile work.
 type componentSpec struct {
-	BinaryName      string
-	PackageDir      string
-	ImageName       string
-	PackageFuncName string
+	BinaryName       string
+	PackageDir       string
+	ImageName        string
+	PackageFuncName  string
+	DockerfileTarget string
 }
 
 // GenMagefile generates the source code for mage which is a Make-like tool
@@ -112,10 +113,11 @@ func GenMagefile(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 	}
 	apiPackageFuncName := "restApiImagePackage"
 	allComponents = append(allComponents, componentSpec{
-		BinaryName:      "rest-api",
-		PackageDir:      "cmd/rest-api",
-		ImageName:       apiImageName,
-		PackageFuncName: apiPackageFuncName,
+		BinaryName:       "rest-api",
+		PackageDir:       "cmd/rest-api",
+		ImageName:        apiImageName,
+		PackageFuncName:  apiPackageFuncName,
+		DockerfileTarget: "release",
 	})
 	emitImagePackageFunc(f, apiPackageFuncName, "REST API", "release", "rest-api", apiImageName)
 	emitImageFunc(f, buildApiImageFuncName, "REST API", "rest-api", "cmd/rest-api", apiPackageFuncName)
@@ -136,10 +138,11 @@ func GenMagefile(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 	}
 	dbMigratorPackageFuncName := "dbMigratorImagePackage"
 	allComponents = append(allComponents, componentSpec{
-		BinaryName:      "database-migrator",
-		PackageDir:      "cmd/database-migrator",
-		ImageName:       dbMigratorImageName,
-		PackageFuncName: dbMigratorPackageFuncName,
+		BinaryName:       "database-migrator",
+		PackageDir:       "cmd/database-migrator",
+		ImageName:        dbMigratorImageName,
+		PackageFuncName:  dbMigratorPackageFuncName,
+		DockerfileTarget: "release",
 	})
 	emitImagePackageFunc(f, dbMigratorPackageFuncName, "database migrator", "release", "database-migrator", dbMigratorImageName)
 	emitImageFunc(f, buildDbMigratorImageFuncName, "database migrator", "database-migrator", "cmd/database-migrator", dbMigratorPackageFuncName)
@@ -158,10 +161,11 @@ func GenMagefile(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 
 		agentPackageFuncName := "agentImagePackage"
 		allComponents = append(allComponents, componentSpec{
-			BinaryName:      "agent",
-			PackageDir:      "cmd/agent",
-			ImageName:       "threeport-agent",
-			PackageFuncName: agentPackageFuncName,
+			BinaryName:       "agent",
+			PackageDir:       "cmd/agent",
+			ImageName:        "threeport-agent",
+			PackageFuncName:  agentPackageFuncName,
+			DockerfileTarget: "release",
 		})
 		emitImagePackageFunc(f, agentPackageFuncName, "agent", "release", "agent", "threeport-agent")
 		emitImageFunc(f, buildAgentImageFuncName, "agent", "agent", "cmd/agent", agentPackageFuncName)
@@ -199,10 +203,11 @@ func GenMagefile(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 
 			packageFuncName := fmt.Sprintf("%sControllerImagePackage", strcase.ToLowerCamel(objGroup.ControllerDomain))
 			allComponents = append(allComponents, componentSpec{
-				BinaryName:      objGroup.ControllerName,
-				PackageDir:      packageDir,
-				ImageName:       imageName,
-				PackageFuncName: packageFuncName,
+				BinaryName:       objGroup.ControllerName,
+				PackageDir:       packageDir,
+				ImageName:        imageName,
+				PackageFuncName:  packageFuncName,
+				DockerfileTarget: objGroup.DockerfileTarget,
 			})
 			target := objGroup.DockerfileTarget
 			if target == "" {
@@ -477,13 +482,34 @@ func GenMagefile(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 		}
 		g.Line()
 
+		// build a map of components that need a non-default Dockerfile target.
+		nonDefaultTargets := Dict{}
+		for _, c := range allComponents {
+			if c.DockerfileTarget != "" && c.DockerfileTarget != "release" {
+				nonDefaultTargets[Lit(c.BinaryName)] = Lit(c.DockerfileTarget)
+			}
+		}
+		if len(nonDefaultTargets) > 0 {
+			g.Comment("components that require a non-standard Dockerfile target; all others use \"release\".")
+			g.Id("componentTargets").Op(":=").Map(String()).String().Values(nonDefaultTargets)
+			g.Id("dockerfileTarget").Op(":=").Lit("release")
+			g.If(
+				List(Id("t"), Id("ok")).Op(":=").Id("componentTargets").Index(Id("component")).Op(";").Id("ok"),
+			).Block(
+				Id("dockerfileTarget").Op("=").Id("t"),
+			)
+		} else {
+			g.Id("dockerfileTarget").Op(":=").Lit("release")
+		}
+		g.Line()
+
 		g.If(Err().Op(":=").Qual(
 			"github.com/threeport/threeport/pkg/util/v0",
 			"BuildImage",
 		).Call(
 			Line().Id("workingDir"),
 			Line().Lit("Dockerfile"),
-			Line().Lit("release"),
+			Line().Id("dockerfileTarget"),
 			Line().Id("arch"),
 			Line().Id("component"),
 			Line().Lit("bin"),

--- a/sdk-config.yaml
+++ b/sdk-config.yaml
@@ -157,6 +157,7 @@ ApiObjectGroups:
       Tptctl:
         Enabled: true
 - Name: helm_workload
+  DockerfileTarget: release-helm
   Objects:
     - Name: HelmWorkloadDefinition
       Versions:


### PR DESCRIPTION
Fixes:
* Helm workload controller docker images was missing `/var/helm/.cache/helm` directory.  Also added `/var/helm/.local/share/helm` at Greptile suggestion.  Updated `BuildImage` mage target accordingly.
* `LoadImage` mage target not working for the custom dockerfile targets.
* A bug in helm-workload-controller and kubernetes-workload-controller that caused a failure managing the `ThreeportWorkload` K8s custom resource (used by threeport-agent) when a `HelmWorkloadInstance` or `KubernetesWorkloadInstance` is created, deleted, and then re-created.