### PR TITLE
fix: correct helm storage namespace and RBAC for helm-workload-controller

### DIFF
--- a/internal/helm-workload/v0_helm_workload_instance.go
+++ b/internal/helm-workload/v0_helm_workload_instance.go
@@ -18,6 +18,7 @@ import (
 	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	"helm.sh/helm/v3/pkg/repo"
+	"helm.sh/helm/v3/pkg/storage/driver"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,6 +121,7 @@ func v0HelmWorkloadInstanceCreated(
 		if uninstallErr := uninstallHelmRelease(
 			install.ReleaseName,
 			actionConf,
+			log,
 		); uninstallErr != nil {
 			return 0, fmt.Errorf("failed to uninstall helm release: %w after failed to install helm chart: %w", uninstallErr, err)
 		}
@@ -312,6 +314,7 @@ func v0HelmWorkloadInstanceDeleted(
 	if err := uninstallHelmRelease(
 		helmReleaseName(helmWorkloadInstance),
 		actionConf,
+		log,
 	); err != nil {
 		return 0, fmt.Errorf("failed to uninstall helm release: %w", err)
 	}
@@ -378,16 +381,24 @@ func v0HelmWorkloadInstanceDeleted(
 func uninstallHelmRelease(
 	releaseName string,
 	actionConf *action.Configuration,
+	log *logr.Logger,
 ) error {
 	// set up uninstall action
 	uninstall := action.NewUninstall(actionConf)
 
-	// ignore error if release not found
-	uninstall.IgnoreNotFound = true
-
 	// run uninstall action
 	_, err := uninstall.Run(releaseName)
 	if err != nil {
+		// If the release is not found, log a warning and continue — the
+		// Kubernetes resources may have already been removed or the Helm
+		// release was never successfully stored (e.g. a failed prior install).
+		// Do NOT silently swallow this with IgnoreNotFound=true: surfacing it
+		// here makes storage-namespace mismatches and other storage failures
+		// visible instead of masking them as successful uninstalls.
+		if errors.Is(err, driver.ErrReleaseNotFound) {
+			log.Info("helm release not found during uninstall — may have been removed already", "releaseName", releaseName)
+			return nil
+		}
 		return fmt.Errorf("failed to uninstall helm chart: %w", err)
 	}
 
@@ -441,11 +452,21 @@ func getHelmActionConfig(
 		return nil, nil, nil, nil, fmt.Errorf("failed to create helm registry client: %w", err)
 	}
 
+	// Helm stores release tracking secrets in the namespace passed to Init.
+	// Use the release namespace so that the Helm storage is co-located with the
+	// release resources rather than being determined by the controller pod's
+	// in-cluster default namespace (which could differ between installs and
+	// uninstalls if the pod is restarted or moved).
+	helmStorageNamespace := settings.Namespace()
+	if helmWorkloadInstance.ReleaseNamespace != nil && *helmWorkloadInstance.ReleaseNamespace != "" {
+		helmStorageNamespace = *helmWorkloadInstance.ReleaseNamespace
+	}
+
 	// create helm action config
 	actionConfig := new(action.Configuration)
 	if err := actionConfig.Init(
 		customGetter,
-		settings.Namespace(),
+		helmStorageNamespace,
 		os.Getenv("HELM_DRIVER"),
 		func(format string, v ...interface{}) {
 			fmt.Sprintf(format, v)

--- a/internal/helm-workload/v0_helm_workload_instance.go
+++ b/internal/helm-workload/v0_helm_workload_instance.go
@@ -58,8 +58,20 @@ func v0HelmWorkloadInstanceCreated(
 		return 0, fmt.Errorf("failed to get helm workload definition: %w", err)
 	}
 
+	// Resolve the release namespace before initialising the Helm action config
+	// so the tracking secret is stored in the same namespace on both install and
+	// uninstall. Auto-generate a namespace when none is specified, and persist
+	// it on helmWorkloadInstance so the API record is updated after install.
+	var releaseNamespace string
+	if helmWorkloadInstance.ReleaseNamespace != nil && *helmWorkloadInstance.ReleaseNamespace != "" {
+		releaseNamespace = *helmWorkloadInstance.ReleaseNamespace
+	} else {
+		releaseNamespace = fmt.Sprintf("%s-%s", *helmWorkloadInstance.Name, util.RandomAlphaString(10))
+		helmWorkloadInstance.ReleaseNamespace = &releaseNamespace
+	}
+
 	// get helm action config, env settings and kube client
-	actionConf, settings, kubeClient, _, err := getHelmActionConfig(r, helmWorkloadInstance)
+	actionConf, settings, kubeClient, _, err := getHelmActionConfig(r, helmWorkloadInstance, releaseNamespace)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get a helm action config: %w", err)
 	}
@@ -88,13 +100,7 @@ func v0HelmWorkloadInstanceCreated(
 
 	// configure release name and namespace
 	install.ReleaseName = helmReleaseName(helmWorkloadInstance)
-	if helmWorkloadInstance.ReleaseNamespace != nil && *helmWorkloadInstance.ReleaseNamespace != "" {
-		install.Namespace = *helmWorkloadInstance.ReleaseNamespace
-	} else {
-		generatedNamespace := fmt.Sprintf("%s-%s", *helmWorkloadInstance.Name, util.RandomAlphaString(10))
-		install.Namespace = generatedNamespace
-		helmWorkloadInstance.ReleaseNamespace = &generatedNamespace
-	}
+	install.Namespace = releaseNamespace
 
 	install.CreateNamespace = true
 	install.DependencyUpdate = true
@@ -242,7 +248,7 @@ func v0HelmWorkloadInstanceUpdated(
 	}
 
 	// get helm action config, env settings and kube client
-	actionConf, settings, _, _, err := getHelmActionConfig(r, helmWorkloadInstance)
+	actionConf, settings, _, _, err := getHelmActionConfig(r, helmWorkloadInstance, *helmWorkloadInstance.ReleaseNamespace)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get a helm action config: %w", err)
 	}
@@ -305,7 +311,7 @@ func v0HelmWorkloadInstanceDeleted(
 	log *logr.Logger,
 ) (int64, error) {
 	// get helm action config and kube client
-	actionConf, _, kubeClient, mapper, err := getHelmActionConfig(r, helmWorkloadInstance)
+	actionConf, _, kubeClient, mapper, err := getHelmActionConfig(r, helmWorkloadInstance, *helmWorkloadInstance.ReleaseNamespace)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get a helm action config: %w", err)
 	}
@@ -410,6 +416,7 @@ func uninstallHelmRelease(
 func getHelmActionConfig(
 	r *controller.Reconciler,
 	helmWorkloadInstance *v0.HelmWorkloadInstance,
+	releaseNamespace string,
 ) (*action.Configuration, *cli.EnvSettings, dynamic.Interface, *meta.RESTMapper, error) {
 	// get kubernetes runtime instance
 	kubernetesRuntimeInstance, err := client.GetKubernetesRuntimeInstanceByID(
@@ -452,21 +459,11 @@ func getHelmActionConfig(
 		return nil, nil, nil, nil, fmt.Errorf("failed to create helm registry client: %w", err)
 	}
 
-	// Helm stores release tracking secrets in the namespace passed to Init.
-	// Use the release namespace so that the Helm storage is co-located with the
-	// release resources rather than being determined by the controller pod's
-	// in-cluster default namespace (which could differ between installs and
-	// uninstalls if the pod is restarted or moved).
-	helmStorageNamespace := settings.Namespace()
-	if helmWorkloadInstance.ReleaseNamespace != nil && *helmWorkloadInstance.ReleaseNamespace != "" {
-		helmStorageNamespace = *helmWorkloadInstance.ReleaseNamespace
-	}
-
 	// create helm action config
 	actionConfig := new(action.Configuration)
 	if err := actionConfig.Init(
 		customGetter,
-		helmStorageNamespace,
+		releaseNamespace,
 		os.Getenv("HELM_DRIVER"),
 		func(format string, v ...interface{}) {
 			fmt.Sprintf(format, v)

--- a/internal/helm-workload/v0_helm_workload_instance.go
+++ b/internal/helm-workload/v0_helm_workload_instance.go
@@ -316,12 +316,20 @@ func v0HelmWorkloadInstanceDeleted(
 	helmWorkloadInstance *v0.HelmWorkloadInstance,
 	log *logr.Logger,
 ) (int64, error) {
-	if helmWorkloadInstance.ReleaseNamespace == nil || *helmWorkloadInstance.ReleaseNamespace == "" {
-		return 0, fmt.Errorf("helm workload instance has no release namespace set — cannot determine helm storage namespace for uninstall")
+	// If ReleaseNamespace was never persisted (install failed before
+	// UpdateHelmWorkloadInstance was reached), we cannot look up the exact Helm
+	// storage namespace. Fall back to the controller default so we can still
+	// obtain a kube client; the uninstall will get ErrReleaseNotFound and
+	// continue gracefully, and namespace deletion is skipped below.
+	releaseNamespace := cli.New().Namespace()
+	if helmWorkloadInstance.ReleaseNamespace != nil && *helmWorkloadInstance.ReleaseNamespace != "" {
+		releaseNamespace = *helmWorkloadInstance.ReleaseNamespace
+	} else {
+		log.Info("helm workload instance has no persisted release namespace — install likely failed before completion; proceeding with best-effort cleanup")
 	}
 
 	// get helm action config and kube client
-	actionConf, _, kubeClient, mapper, err := getHelmActionConfig(r, helmWorkloadInstance, *helmWorkloadInstance.ReleaseNamespace)
+	actionConf, _, kubeClient, mapper, err := getHelmActionConfig(r, helmWorkloadInstance, releaseNamespace)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get a helm action config: %w", err)
 	}

--- a/internal/helm-workload/v0_helm_workload_instance.go
+++ b/internal/helm-workload/v0_helm_workload_instance.go
@@ -221,11 +221,13 @@ func v0HelmWorkloadInstanceCreated(
 	}
 	// update helm workload instance reconciled field
 	helmWorkloadInstance.Reconciled = util.Ptr(true)
-	_, err = client.UpdateHelmWorkloadInstance(
+	if _, err = client.UpdateHelmWorkloadInstance(
 		r.APIClient,
 		r.APIServer,
 		helmWorkloadInstance,
-	)
+	); err != nil {
+		return 0, fmt.Errorf("failed to update helm workload instance reconciled field: %w", err)
+	}
 
 	return 0, nil
 }

--- a/internal/helm-workload/v0_helm_workload_instance.go
+++ b/internal/helm-workload/v0_helm_workload_instance.go
@@ -247,6 +247,10 @@ func v0HelmWorkloadInstanceUpdated(
 		return 0, fmt.Errorf("failed to get helm workload definition: %w", err)
 	}
 
+	if helmWorkloadInstance.ReleaseNamespace == nil || *helmWorkloadInstance.ReleaseNamespace == "" {
+		return 0, fmt.Errorf("helm workload instance has no release namespace set — cannot determine helm storage namespace for upgrade")
+	}
+
 	// get helm action config, env settings and kube client
 	actionConf, settings, _, _, err := getHelmActionConfig(r, helmWorkloadInstance, *helmWorkloadInstance.ReleaseNamespace)
 	if err != nil {
@@ -310,6 +314,10 @@ func v0HelmWorkloadInstanceDeleted(
 	helmWorkloadInstance *v0.HelmWorkloadInstance,
 	log *logr.Logger,
 ) (int64, error) {
+	if helmWorkloadInstance.ReleaseNamespace == nil || *helmWorkloadInstance.ReleaseNamespace == "" {
+		return 0, fmt.Errorf("helm workload instance has no release namespace set — cannot determine helm storage namespace for uninstall")
+	}
+
 	// get helm action config and kube client
 	actionConf, _, kubeClient, mapper, err := getHelmActionConfig(r, helmWorkloadInstance, *helmWorkloadInstance.ReleaseNamespace)
 	if err != nil {

--- a/internal/helm-workload/v0_helm_workload_instance.go
+++ b/internal/helm-workload/v0_helm_workload_instance.go
@@ -385,6 +385,7 @@ func v0HelmWorkloadInstanceDeleted(
 		for _, hwi := range *helmWorkloadInstances {
 			if hwi.ReleaseNamespace != nil &&
 				*hwi.ReleaseNamespace == *helmWorkloadInstance.ReleaseNamespace &&
+				hwi.ID != nil &&
 				*hwi.ID != *helmWorkloadInstance.ID {
 				return 0, nil
 			}

--- a/internal/helm-workload/v0_helm_workload_instance.go
+++ b/internal/helm-workload/v0_helm_workload_instance.go
@@ -381,11 +381,13 @@ func v0HelmWorkloadInstanceDeleted(
 
 	// if any other helm workload instances are using the namespace, do not
 	// delete it
-	for _, hwi := range *helmWorkloadInstances {
-		if hwi.ReleaseNamespace != nil &&
-			*hwi.ReleaseNamespace == *helmWorkloadInstance.ReleaseNamespace &&
-			*hwi.ID != *helmWorkloadInstance.ID {
-			return 0, nil
+	if helmWorkloadInstance.ReleaseNamespace != nil && *helmWorkloadInstance.ReleaseNamespace != "" {
+		for _, hwi := range *helmWorkloadInstances {
+			if hwi.ReleaseNamespace != nil &&
+				*hwi.ReleaseNamespace == *helmWorkloadInstance.ReleaseNamespace &&
+				*hwi.ID != *helmWorkloadInstance.ID {
+				return 0, nil
+			}
 		}
 	}
 

--- a/pkg/threeport-installer/v0/components.go
+++ b/pkg/threeport-installer/v0/components.go
@@ -358,6 +358,40 @@ func (cpi *ControlPlaneInstaller) InstallThreeportControllers(
 		return fmt.Errorf("failed to create controller secret: %w", err)
 	}
 
+	// ClusterRole granting all controllers CRUD on ThreeportWorkload resources.
+	// ThreeportWorkload is cluster-scoped, so a ClusterRole is required.
+	threeportWorkloadClusterRole := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata": map[string]interface{}{
+				"name": "threeport-controllers-threeportworkloads",
+			},
+			"rules": []interface{}{
+				map[string]interface{}{
+					"apiGroups": []interface{}{
+						"control-plane.threeport.io",
+					},
+					"resources": []interface{}{
+						"threeportworkloads",
+					},
+					"verbs": []interface{}{
+						"create",
+						"delete",
+						"get",
+						"list",
+						"patch",
+						"update",
+						"watch",
+					},
+				},
+			},
+		},
+	}
+	if err := cpi.CreateOrUpdateKubeResource(threeportWorkloadClusterRole, kubeClient, mapper); err != nil {
+		return fmt.Errorf("failed to create threeport controllers threeportworkloads cluster role: %w", err)
+	}
+
 	for _, controller := range cpi.Opts.ControllerList {
 		if !*controller.Enabled {
 			continue
@@ -423,6 +457,87 @@ func (cpi *ControlPlaneInstaller) InstallThreeportControllers(
 		}
 		if err := cpi.CreateOrUpdateKubeResource(serviceAccount, kubeClient, mapper); err != nil {
 			return fmt.Errorf("failed to create controller service account: %w", err)
+		}
+
+		// Bind the shared ClusterRole to this controller's service account so it
+		// can manage ThreeportWorkload resources.
+		threeportWorkloadSubjects := []interface{}{
+			map[string]interface{}{
+				"kind":      "ServiceAccount",
+				"name":      controller.ServiceAccountName,
+				"namespace": cpi.Opts.Namespace,
+			},
+		}
+		// On GKE with Workload Identity enabled, the kube-apiserver authenticates
+		// pod tokens as "serviceAccount:PROJECT.svc.id.goog[NAMESPACE/KSA]" rather
+		// than "system:serviceaccount:NAMESPACE:NAME". The kind:ServiceAccount
+		// subject only matches the latter, so we add a kind:User subject for the
+		// WI principal to ensure RBAC applies to the actual pod identity.
+		if cpi.Opts.InfraProvider == v0.KubernetesRuntimeInfraProviderGKE && cpi.Opts.GcpProjectId != "" {
+			threeportWorkloadSubjects = append(threeportWorkloadSubjects, map[string]interface{}{
+				"kind":      "User",
+				"name":      fmt.Sprintf("serviceAccount:%s.svc.id.goog[%s/%s]", cpi.Opts.GcpProjectId, cpi.Opts.Namespace, controller.ServiceAccountName),
+				"apiGroup":  "rbac.authorization.k8s.io",
+			})
+		}
+		threeportWorkloadClusterRoleBinding := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+				"kind":       "ClusterRoleBinding",
+				"metadata": map[string]interface{}{
+					"name": fmt.Sprintf("%s-threeportworkloads", controller.ServiceAccountName),
+				},
+				"roleRef": map[string]interface{}{
+					"apiGroup": "rbac.authorization.k8s.io",
+					"kind":     "ClusterRole",
+					"name":     "threeport-controllers-threeportworkloads",
+				},
+				"subjects": threeportWorkloadSubjects,
+			},
+		}
+		if err := cpi.CreateOrUpdateKubeResource(threeportWorkloadClusterRoleBinding, kubeClient, mapper); err != nil {
+			return fmt.Errorf("failed to create threeportworkloads cluster role binding for %s: %w", controller.Name, err)
+		}
+
+		// The helm-workload-controller deploys arbitrary Helm charts that can
+		// define any Kubernetes resource type in any namespace. cluster-admin is
+		// required so it can manage the full lifecycle of chart resources.
+		// On GKE with Workload Identity, Helm API calls are made as the WI
+		// principal (via ADC token refresh), so both the ServiceAccount and User
+		// subjects are needed.
+		if controller.Name == ThreeportHelmWorkloadControllerName {
+			helmClusterAdminSubjects := []interface{}{
+				map[string]interface{}{
+					"kind":      "ServiceAccount",
+					"name":      controller.ServiceAccountName,
+					"namespace": cpi.Opts.Namespace,
+				},
+			}
+			if cpi.Opts.InfraProvider == v0.KubernetesRuntimeInfraProviderGKE && cpi.Opts.GcpProjectId != "" {
+				helmClusterAdminSubjects = append(helmClusterAdminSubjects, map[string]interface{}{
+					"kind":     "User",
+					"name":     fmt.Sprintf("serviceAccount:%s.svc.id.goog[%s/%s]", cpi.Opts.GcpProjectId, cpi.Opts.Namespace, controller.ServiceAccountName),
+					"apiGroup": "rbac.authorization.k8s.io",
+				})
+			}
+			helmClusterAdminBinding := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "rbac.authorization.k8s.io/v1",
+					"kind":       "ClusterRoleBinding",
+					"metadata": map[string]interface{}{
+						"name": "helm-workload-controller-cluster-admin",
+					},
+					"roleRef": map[string]interface{}{
+						"apiGroup": "rbac.authorization.k8s.io",
+						"kind":     "ClusterRole",
+						"name":     "cluster-admin",
+					},
+					"subjects": helmClusterAdminSubjects,
+				},
+			}
+			if err := cpi.CreateOrUpdateKubeResource(helmClusterAdminBinding, kubeClient, mapper); err != nil {
+				return fmt.Errorf("failed to create helm-workload-controller cluster-admin binding: %w", err)
+			}
 		}
 
 		if err := cpi.UpdateControllerDeployment(


### PR DESCRIPTION
Helm release tracking secrets were being stored in the controller's default namespace rather than the release namespace, causing uninstalls to fail with ErrReleaseNotFound when the two differed. The storage namespace is now derived from ReleaseNamespace so Helm state is always co-located with the release resources.

The uninstall path no longer uses IgnoreNotFound=true; instead it explicitly checks for driver.ErrReleaseNotFound and logs a warning, making storage-namespace mismatches and other storage failures visible rather than masking them as successful uninstalls.

Installer changes add a shared ClusterRole for ThreeportWorkload (K8s CR used by threeport-agent) management and bind it to each controller's service account, with GKE Workload Identity support (kind:User subjects). The helm-workload-controller also receives a cluster-admin binding since it must manage arbitrary chart resources across any namespace.