### PR TITLE
chore: add new field to externaldns CRD in installer

### DIFF
--- a/internal/gateway/manifests.go
+++ b/internal/gateway/manifests.go
@@ -38,6 +38,7 @@ func getExternalDnsYaml(
 	domain,
 	provider,
 	iamRoleArn,
+	gcpProject,
 	glooEdgeNamespace,
 	kubernetesRuntimeInstanceID string,
 ) (string, error) {
@@ -66,6 +67,7 @@ func getExternalDnsYaml(
 				"provider":           provider,
 				"serviceAccountName": "external-dns",
 				"iamRoleArn":         iamRoleArn,
+				"gcpProject":         gcpProject,
 				"extraArgs":          extraArgs,
 			},
 		},

--- a/internal/gateway/v0_domain_name_instance.go
+++ b/internal/gateway/v0_domain_name_instance.go
@@ -186,6 +186,31 @@ func confirmDnsControllerDeployed(
 			*domainNameDefinition.Domain,
 			"route53",
 			resourceInventory.DnsManagementRole.RoleArn,
+			"",
+			glooEdgeNamespace,
+			kubernetesRuntimeInstanceID,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create external dns: %w", err)
+		}
+
+	case v0.KubernetesRuntimeInfraProviderGKE:
+
+		gcpGkeRuntimeInstance, err := client.GetGcpGkeKubernetesRuntimeInstanceByK8sRuntimeInst(r.APIClient, r.APIServer, *domainNameInstance.KubernetesRuntimeInstanceID)
+		if err != nil {
+			return fmt.Errorf("failed to get GCP GKE runtime instance: %w", err)
+		}
+
+		gcpProvider, err := client.GetGcpProviderByID(r.APIClient, r.APIServer, *gcpGkeRuntimeInstance.GcpProviderID)
+		if err != nil {
+			return fmt.Errorf("failed to get GCP provider: %w", err)
+		}
+
+		externalDnsYaml, err = getExternalDnsYaml(
+			*domainNameDefinition.Domain,
+			"google",
+			"",
+			*gcpProvider.ProjectID,
 			glooEdgeNamespace,
 			kubernetesRuntimeInstanceID,
 		)
@@ -198,6 +223,7 @@ func confirmDnsControllerDeployed(
 		externalDnsYaml, err = getExternalDnsYaml(
 			*domainNameDefinition.Domain,
 			"none",
+			"",
 			"",
 			glooEdgeNamespace,
 			kubernetesRuntimeInstanceID,

--- a/pkg/threeport-installer/v0/support_services.go
+++ b/pkg/threeport-installer/v0/support_services.go
@@ -353,6 +353,10 @@ func InstallThreeportCRDs(
 											"domainName": map[string]interface{}{
 												"type": "string",
 											},
+											"gcpProject": map[string]interface{}{
+												"description": "GCP project ID used when provider is \"google\".",
+												"type":        "string",
+											},
 											"extraArgs": map[string]interface{}{
 												"description": "Extra arguments to be passed into the External DNS container.",
 												"items": map[string]interface{}{

--- a/pkg/threeport-installer/v0/support_services.go
+++ b/pkg/threeport-installer/v0/support_services.go
@@ -351,7 +351,8 @@ func InstallThreeportCRDs(
 												"type": "object",
 											},
 											"domainName": map[string]interface{}{
-												"type": "string",
+												"description": "The DNS domain name to manage records for.",
+												"type":        "string",
 											},
 											"gcpProject": map[string]interface{}{
 												"description": "GCP project ID used when provider is \"google\".",


### PR DESCRIPTION
This field allows the GCP project ID to be properly set.  Without it, it tries to use a default project ID.