### PR TITLE
feat: grant workload controllers cluster-admin on managed GKE clusters

### DIFF
--- a/internal/kubernetes-runtime/v0_kubernetes_runtime_instance.go
+++ b/internal/kubernetes-runtime/v0_kubernetes_runtime_instance.go
@@ -259,6 +259,33 @@ func v0KubernetesRuntimeInstanceUpdated(
 		}
 	}
 
+	// On GKE, the control-plane workload controllers authenticate to this
+	// managed cluster as their own Workload Identity principals (via per-request
+	// ADC tokens), so the managed cluster must grant those principals the access
+	// they need to deploy workloads. This mirrors the bindings created on the
+	// control-plane cluster in InstallThreeportControllers. It applies only when
+	// both this managed cluster and the control-plane host run on GKE; the host
+	// instance is skipped because its bindings are created at control-plane
+	// install time.
+	isControlPlaneHost := kubernetesRuntimeInstance.ThreeportControlPlaneHost != nil &&
+		*kubernetesRuntimeInstance.ThreeportControlPlaneHost
+	if !isControlPlaneHost &&
+		*kubernetesRuntimeDefinition.InfraProvider == v0.KubernetesRuntimeInfraProviderGKE {
+		controlPlaneGcpProject, err := controlPlaneGkeProject(r)
+		if err != nil {
+			return 0, fmt.Errorf("failed to determine control plane GCP project for workload controller RBAC: %w", err)
+		}
+		if controlPlaneGcpProject != "" {
+			if err := cpi.InstallComputeSpaceWorkloadControllerRBAC(
+				dynamicKubeClient,
+				mapper,
+				controlPlaneGcpProject,
+			); err != nil {
+				return 0, fmt.Errorf("failed to install workload controller RBAC on managed cluster: %w", err)
+			}
+		}
+	}
+
 	return 0, nil
 }
 
@@ -341,6 +368,63 @@ func v0KubernetesRuntimeInstanceDeleted(
 	}
 
 	return 0, nil
+}
+
+// controlPlaneGkeProject returns the GCP project ID of the GKE cluster hosting
+// the threeport control plane, or "" if the control plane is not hosted on GKE.
+// It is used to construct the Workload Identity principals of the control-plane
+// controllers when granting them access to managed clusters. The control-plane
+// host is the KubernetesRuntimeInstance marked ThreeportControlPlaneHost.
+func controlPlaneGkeProject(r *controller.Reconciler) (string, error) {
+	instances, err := client.GetKubernetesRuntimeInstances(r.APIClient, r.APIServer)
+	if err != nil {
+		return "", fmt.Errorf("failed to list kubernetes runtime instances: %w", err)
+	}
+
+	var hostInstance *v0.KubernetesRuntimeInstance
+	for i := range *instances {
+		if (*instances)[i].ThreeportControlPlaneHost != nil && *(*instances)[i].ThreeportControlPlaneHost {
+			hostInstance = &(*instances)[i]
+			break
+		}
+	}
+	if hostInstance == nil {
+		return "", fmt.Errorf("no control plane host kubernetes runtime instance found")
+	}
+
+	hostDefinition, err := client.GetKubernetesRuntimeDefinitionByID(
+		r.APIClient,
+		r.APIServer,
+		*hostInstance.KubernetesRuntimeDefinitionID,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to get control plane host runtime definition: %w", err)
+	}
+
+	// Only GKE-hosted control planes present Workload Identity principals to
+	// managed clusters; for any other host provider there is no WI principal to
+	// bind, so signal "not applicable" with an empty project.
+	if hostDefinition.InfraProvider == nil ||
+		*hostDefinition.InfraProvider != v0.KubernetesRuntimeInfraProviderGKE {
+		return "", nil
+	}
+	if hostDefinition.InfraProviderAccountName == nil {
+		return "", fmt.Errorf("control plane host runtime definition has no infra provider account name")
+	}
+
+	gcpProvider, err := client.GetGcpProviderByName(
+		r.APIClient,
+		r.APIServer,
+		*hostDefinition.InfraProviderAccountName,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to get GCP provider %q: %w", *hostDefinition.InfraProviderAccountName, err)
+	}
+	if gcpProvider.ProjectID == nil {
+		return "", fmt.Errorf("GCP provider %q has no project ID", *hostDefinition.InfraProviderAccountName)
+	}
+
+	return *gcpProvider.ProjectID, nil
 }
 
 // GetCloudProviderForInfraProvider returns the cloud provider for a given

--- a/pkg/kube/v0/cluster.go
+++ b/pkg/kube/v0/cluster.go
@@ -27,7 +27,6 @@ import (
 	v0 "github.com/threeport/threeport/pkg/api/v0"
 	client "github.com/threeport/threeport/pkg/client/v0"
 	"github.com/threeport/threeport/pkg/encryption/v0"
-	client_lib "github.com/threeport/threeport/pkg/client/lib/v0"
 	util "github.com/threeport/threeport/pkg/util/v0"
 )
 
@@ -159,9 +158,13 @@ func GetRestConfig(
 		kubeAPIEndpoint = "kubernetes.default.svc.cluster.local"
 	}
 
-	// OKE tokens are cheap (local RSA signature) and short-lived, so always
-	// mint a fresh one per request rather than maintaining a stored
-	// ConnectionToken.
+	// OKE and GKE authenticate with a token minted per request rather than a
+	// single bearer token persisted on the runtime instance record.  This
+	// ensures each caller authenticates as its own identity: OKE tokens are
+	// cheap local RSA signatures, and on GKE every controller pod has a distinct
+	// Workload Identity principal, so a shared/persisted token would cause
+	// callers to authenticate as whichever pod last refreshed it — leading to
+	// intermittent, identity-dependent RBAC failures.
 	if runtime.KubernetesRuntimeDefinitionID != nil {
 		definition, err := client.GetKubernetesRuntimeDefinitionByID(
 			threeportAPIClient,
@@ -171,11 +174,22 @@ func GetRestConfig(
 		if err != nil {
 			return nil, fmt.Errorf("failed to get kubernetes runtime definition: %w", err)
 		}
-		if *definition.InfraProvider == v0.KubernetesRuntimeInfraProviderOKE {
-			tokenGenerator, err := buildOKETokenGenerator(runtime, threeportAPIClient, threeportAPIEndpoint, encryptionKey)
+
+		var tokenGenerator func() (string, error)
+		switch *definition.InfraProvider {
+		case v0.KubernetesRuntimeInfraProviderOKE:
+			tokenGenerator, err = buildOKETokenGenerator(runtime, threeportAPIClient, threeportAPIEndpoint, encryptionKey)
 			if err != nil {
 				return nil, fmt.Errorf("failed to build OKE token generator: %w", err)
 			}
+		case v0.KubernetesRuntimeInfraProviderGKE:
+			tokenGenerator, err = buildGKETokenGenerator()
+			if err != nil {
+				return nil, fmt.Errorf("failed to build GKE token generator: %w", err)
+			}
+		}
+
+		if tokenGenerator != nil {
 			return &rest.Config{
 				Host: kubeAPIEndpoint,
 				TLSClientConfig: rest.TLSClientConfig{
@@ -266,16 +280,6 @@ func GetRestConfig(
 						encryptionKey,
 					); err != nil {
 						return nil, fmt.Errorf("failed to refresh connection token for EKS cluster: %w", err)
-					}
-					restConfig = *config
-				case v0.KubernetesRuntimeInfraProviderGKE:
-					if config, err = refreshGKEConnection(
-						runtime,
-						threeportAPIClient,
-						threeportAPIEndpoint,
-						encryptionKey,
-					); err != nil {
-						return nil, fmt.Errorf("failed to refresh connection token for GKE cluster: %w", err)
 					}
 					restConfig = *config
 				default:
@@ -483,57 +487,41 @@ func refreshEKSConnection(
 	return &restConfig, nil
 }
 
-// refreshGKEConnection refreshes the connection token for a GKE cluster.
-func refreshGKEConnection(
-	runtimeInstance *v0.KubernetesRuntimeInstance,
-	threeportAPIClient *http.Client,
-	threeportAPIEndpoint string,
-	encryptionKey string,
-) (*rest.Config, error) {
-	ctx := context.Background()
-
-	// get a new access token using Google Application Default Credentials
-	tokenSource, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+// buildGKETokenGenerator returns a closure that mints a fresh GKE bearer token
+// on each call using the caller's Google Application Default Credentials.  The
+// underlying token source caches and refreshes the token internally, so
+// per-request calls are cheap and only contact the metadata server when the
+// cached token is near expiry.
+//
+// Minting the token from the caller's own ADC — rather than reading a single
+// bearer token persisted on the runtime instance record — ensures each
+// controller authenticates to the GKE API as its own Workload Identity
+// principal.  A shared, persisted token would take on the identity of whichever
+// controller last refreshed it, causing intermittent RBAC failures for
+// controllers whose grants differ from that identity's.  It also removes the
+// write-back to the shared runtime instance row, eliminating a source of
+// transaction contention.
+//
+// TODO(#470): this relies on ambient Google ADC, so it only works from a
+// GKE-hosted control plane.  To support a non-GKE-hosted control plane managing
+// a GKE cluster, fall back to google.CredentialsFromJSON using the runtime's
+// GcpProvider.ServiceAccountCredentials (as EKS/OKE do with their stored
+// provider credentials).
+func buildGKETokenGenerator() (func() (string, error), error) {
+	tokenSource, err := google.DefaultTokenSource(
+		context.Background(),
+		"https://www.googleapis.com/auth/cloud-platform",
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Google token source: %w", err)
 	}
-
-	token, err := tokenSource.Token()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get access token from Google: %w", err)
-	}
-
-	// generate updated rest config
-	restConfig := rest.Config{
-		Host:        *runtimeInstance.APIEndpoint,
-		BearerToken: token.AccessToken,
-		TLSClientConfig: rest.TLSClientConfig{
-			CAData: []byte(*runtimeInstance.CACertificate),
-		},
-	}
-
-	// update threeport API with new connection info
-	runtimeInstance.ConnectionToken = &token.AccessToken
-	runtimeInstance.ConnectionTokenExpiration = &token.Expiry
-	_, err = client.UpdateKubernetesRuntimeInstance(
-		threeportAPIClient,
-		threeportAPIEndpoint,
-		runtimeInstance,
-	)
-	if err != nil {
-		if errors.Is(err, client_lib.ErrObjectOwned) {
-			// the runtime instance is owned by a controller and cannot be updated
-			// directly; the refreshed token is still valid for this request
-			util.CliOutputWarning(fmt.Sprintf(
-				"could not persist refreshed GKE connection token to Threeport API"+
-					" (runtime instance is controller-owned): %v", err,
-			))
-		} else {
-			return nil, fmt.Errorf("failed to update kubernetes runtime instance kubernetes connection info: %w", err)
+	return func() (string, error) {
+		token, err := tokenSource.Token()
+		if err != nil {
+			return "", fmt.Errorf("failed to get access token from Google: %w", err)
 		}
-	}
-
-	return &restConfig, nil
+		return token.AccessToken, nil
+	}, nil
 }
 
 // GetAwsConfigFromAwsProvider returns an aws config from an aws account.

--- a/pkg/threeport-installer/v0/components.go
+++ b/pkg/threeport-installer/v0/components.go
@@ -64,6 +64,59 @@ func (cpi *ControlPlaneInstaller) InstallComputeSpaceControlPlaneComponents(
 	return nil
 }
 
+// InstallComputeSpaceWorkloadControllerRBAC grants the control-plane workload
+// controllers cluster-admin on a managed (compute space) GKE cluster.  The
+// helm-workload-controller and kubernetes-workload-controller deploy arbitrary
+// resources to managed clusters and connect to them as their own GKE Workload
+// Identity principals (via per-request ADC tokens), so the managed cluster must
+// authorize those principals directly.  This mirrors the bindings created on the
+// control-plane cluster in InstallThreeportControllers.
+//
+// Only the kind:User Workload Identity subject is bound: on a remote managed
+// cluster the controllers never authenticate with an in-cluster ServiceAccount
+// token, so a kind:ServiceAccount subject would never match.  gcpProjectID is the
+// project of the GKE cluster hosting the control plane (where the controller pods
+// run), which determines the Workload Identity pool in the principal name.
+func (cpi *ControlPlaneInstaller) InstallComputeSpaceWorkloadControllerRBAC(
+	kubeClient dynamic.Interface,
+	mapper *meta.RESTMapper,
+	gcpProjectID string,
+) error {
+	workloadControllers := []string{
+		ThreeportHelmWorkloadControllerName,
+		ThreeportKubernetesWorkloadControllerName,
+	}
+
+	for _, controllerName := range workloadControllers {
+		clusterAdminBinding := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+				"kind":       "ClusterRoleBinding",
+				"metadata": map[string]interface{}{
+					"name": fmt.Sprintf("%s-cluster-admin", controllerName),
+				},
+				"roleRef": map[string]interface{}{
+					"apiGroup": "rbac.authorization.k8s.io",
+					"kind":     "ClusterRole",
+					"name":     "cluster-admin",
+				},
+				"subjects": []interface{}{
+					map[string]interface{}{
+						"kind":     "User",
+						"name":     fmt.Sprintf("serviceAccount:%s.svc.id.goog[%s/%s]", gcpProjectID, ControlPlaneNamespace, controllerName),
+						"apiGroup": "rbac.authorization.k8s.io",
+					},
+				},
+			},
+		}
+		if err := cpi.CreateOrUpdateKubeResource(clusterAdminBinding, kubeClient, mapper); err != nil {
+			return fmt.Errorf("failed to create %s cluster-admin binding on managed cluster: %w", controllerName, err)
+		}
+	}
+
+	return nil
+}
+
 // UpdateThreeportAPIDeployment installs the threeport API in a Kubernetes
 // cluster.
 func (cpi *ControlPlaneInstaller) UpdateThreeportAPIDeployment(

--- a/pkg/threeport-installer/v0/components.go
+++ b/pkg/threeport-installer/v0/components.go
@@ -499,14 +499,17 @@ func (cpi *ControlPlaneInstaller) InstallThreeportControllers(
 			return fmt.Errorf("failed to create threeportworkloads cluster role binding for %s: %w", controller.Name, err)
 		}
 
-		// The helm-workload-controller deploys arbitrary Helm charts that can
-		// define any Kubernetes resource type in any namespace. cluster-admin is
-		// required so it can manage the full lifecycle of chart resources.
-		// On GKE with Workload Identity, Helm API calls are made as the WI
-		// principal (via ADC token refresh), so both the ServiceAccount and User
-		// subjects are needed.
-		if controller.Name == ThreeportHelmWorkloadControllerName {
-			helmClusterAdminSubjects := []interface{}{
+		// The helm-workload-controller and kubernetes-workload-controller deploy
+		// arbitrary resources — Helm charts or raw manifests — that can define any
+		// Kubernetes resource type in any namespace (including creating
+		// namespaces). cluster-admin is required so they can manage the full
+		// lifecycle of those resources. On GKE with Workload Identity, each
+		// controller authenticates to the target cluster as its own WI principal
+		// (via per-request ADC tokens), so both the ServiceAccount and User
+		// subjects are bound.
+		if controller.Name == ThreeportHelmWorkloadControllerName ||
+			controller.Name == ThreeportKubernetesWorkloadControllerName {
+			clusterAdminSubjects := []interface{}{
 				map[string]interface{}{
 					"kind":      "ServiceAccount",
 					"name":      controller.ServiceAccountName,
@@ -514,29 +517,29 @@ func (cpi *ControlPlaneInstaller) InstallThreeportControllers(
 				},
 			}
 			if cpi.Opts.InfraProvider == v0.KubernetesRuntimeInfraProviderGKE && cpi.Opts.GcpProjectId != "" {
-				helmClusterAdminSubjects = append(helmClusterAdminSubjects, map[string]interface{}{
+				clusterAdminSubjects = append(clusterAdminSubjects, map[string]interface{}{
 					"kind":     "User",
 					"name":     fmt.Sprintf("serviceAccount:%s.svc.id.goog[%s/%s]", cpi.Opts.GcpProjectId, cpi.Opts.Namespace, controller.ServiceAccountName),
 					"apiGroup": "rbac.authorization.k8s.io",
 				})
 			}
-			helmClusterAdminBinding := &unstructured.Unstructured{
+			clusterAdminBinding := &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "rbac.authorization.k8s.io/v1",
 					"kind":       "ClusterRoleBinding",
 					"metadata": map[string]interface{}{
-						"name": "helm-workload-controller-cluster-admin",
+						"name": fmt.Sprintf("%s-cluster-admin", controller.ServiceAccountName),
 					},
 					"roleRef": map[string]interface{}{
 						"apiGroup": "rbac.authorization.k8s.io",
 						"kind":     "ClusterRole",
 						"name":     "cluster-admin",
 					},
-					"subjects": helmClusterAdminSubjects,
+					"subjects": clusterAdminSubjects,
 				},
 			}
-			if err := cpi.CreateOrUpdateKubeResource(helmClusterAdminBinding, kubeClient, mapper); err != nil {
-				return fmt.Errorf("failed to create helm-workload-controller cluster-admin binding: %w", err)
+			if err := cpi.CreateOrUpdateKubeResource(clusterAdminBinding, kubeClient, mapper); err != nil {
+				return fmt.Errorf("failed to create %s cluster-admin binding: %w", controller.Name, err)
 			}
 		}
 


### PR DESCRIPTION
On GKE, threeport control-plane controllers authenticate to Kubernetes clusters using their own [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) principals. This PR fixes how those controllers obtain credentials and ensures both the control-plane cluster and any managed clusters authorize those principals correctly. Together these changes make it possible for a GKE-hosted control plane to deploy workloads to remote GKE clusters reliably.