### PR TITLE
fix: move parent KRI cleanup from tptctl into GKE delete reconciliation

### DIFF
--- a/internal/gcp/gke_lifecycle.go
+++ b/internal/gcp/gke_lifecycle.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	notif "github.com/threeport/threeport/internal/gcp/notif"
 	"github.com/threeport/threeport/internal/provider"
 	v0 "github.com/threeport/threeport/pkg/api/v0"
+	client_lib "github.com/threeport/threeport/pkg/client/lib/v0"
 	client "github.com/threeport/threeport/pkg/client/v0"
 	controller "github.com/threeport/threeport/pkg/controller/v0"
 	notifications "github.com/threeport/threeport/pkg/notifications/v0"
@@ -158,8 +160,49 @@ func (g *gkeLifecycle) SaveCreateOutputs(_ provider.InfraProvider, state *dataty
 	return nil
 }
 
-// OnDeleteConfirmed performs provider-specific post-deletion cleanup.
+// OnDeleteConfirmed triggers deletion of the parent KubernetesRuntimeInstance
+// if it has not already been scheduled for deletion.  This handles the case
+// where a GcpGkeKubernetesRuntimeInstance is deleted directly (not via the
+// KRI deletion flow), leaving the parent KRI orphaned.  In the normal KRI
+// deletion flow the parent is already hard-deleted by the time this runs, so
+// a not-found response is treated as a no-op.
 func (g *gkeLifecycle) OnDeleteConfirmed(_ provider.InfraProvider) error {
+	latest, err := client.GetGcpGkeKubernetesRuntimeInstanceByID(
+		g.r.APIClient,
+		g.r.APIServer,
+		g.instanceID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to get GKE instance for parent KRI cleanup: %w", err)
+	}
+
+	kri, err := client.GetKubernetesRuntimeInstanceByID(
+		g.r.APIClient,
+		g.r.APIServer,
+		*latest.KubernetesRuntimeInstanceID,
+	)
+	if err != nil {
+		if errors.Is(err, client_lib.ErrObjectNotFound) {
+			// KRI already deleted - normal flow where KRI deletion completes
+			// before the GKE cluster destroy finishes
+			return nil
+		}
+		return fmt.Errorf("failed to get parent KRI: %w", err)
+	}
+
+	if kri.DeletionScheduled != nil {
+		// deletion already in progress via the normal KRI flow
+		return nil
+	}
+
+	if _, err = client.DeleteKubernetesRuntimeInstance(
+		g.r.APIClient,
+		g.r.APIServer,
+		*kri.ID,
+	); err != nil {
+		return fmt.Errorf("failed to trigger parent KRI deletion: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/config/v0/gcp_gke_kubernetes_runtime_instance.go
+++ b/pkg/config/v0/gcp_gke_kubernetes_runtime_instance.go
@@ -6,11 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/threeport/threeport/internal/kubernetes-runtime/mapping"
 	api_v0 "github.com/threeport/threeport/pkg/api/v0"
-	client_lib "github.com/threeport/threeport/pkg/client/lib/v0"
 	client_v0 "github.com/threeport/threeport/pkg/client/v0"
 	util "github.com/threeport/threeport/pkg/util/v0"
 )
@@ -314,70 +312,6 @@ func (g *GcpGkeKubernetesRuntimeInstanceConfig) Delete(
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete gcp gke kubernetes runtime instance from Threeport API: %w", err)
-	}
-
-	// wait for GCP GKE kubernetes runtime instance to be deleted
-	util.Retry(90, 10, func() error {
-		if _, err := client_v0.GetGcpGkeKubernetesRuntimeInstanceByName(
-			apiClient,
-			apiEndpoint,
-			*gcpGkeKubernetesRuntimeInstance.Name,
-		); err == nil {
-			return errors.New("GCP GKE kubernetes runtime instance not deleted")
-		}
-		return nil
-	})
-
-	// get kubernetes runtime instance
-	kubernetesRuntimeInstance, err := client_v0.GetKubernetesRuntimeInstanceByID(
-		apiClient,
-		apiEndpoint,
-		*gcpGkeKubernetesRuntimeInstance.KubernetesRuntimeInstanceID,
-	)
-	if err != nil {
-		// if the kubernetes runtime instance wasn't found, there's no more to
-		// do - return the error if something other than 'object not found'
-		if !errors.Is(err, client_lib.ErrObjectNotFound) {
-			return nil, fmt.Errorf("failed to get associated kubernetes runtime instance: %w", err)
-		}
-	}
-	// if kubernetes runtime found, remove it
-	if err == nil {
-		// update kubernetes runtime instance to set the deletion confirmed
-		// timestamp - this will allow deletion of the k8s runtime object without
-		// triggering unnecessary reconciliation
-		now := time.Now().UTC()
-		kubernetesRuntimeInstance.DeletionConfirmed = &now
-		_, err = client_v0.UpdateKubernetesRuntimeInstance(
-			apiClient,
-			apiEndpoint,
-			kubernetesRuntimeInstance,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to update associated kubernetes runtime instance to set deletion confirmed: %w", err)
-		}
-
-		// delete kubernetes runtime instance
-		_, err = client_v0.DeleteKubernetesRuntimeInstance(
-			apiClient,
-			apiEndpoint,
-			*gcpGkeKubernetesRuntimeInstance.KubernetesRuntimeInstanceID,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to delete associated kubernetes runtime instance: %w", err)
-		}
-
-		// wait for kubernetes runtime instance to be deleted
-		util.Retry(10, 1, func() error {
-			if _, err := client_v0.GetKubernetesRuntimeInstanceByName(
-				apiClient,
-				apiEndpoint,
-				*kubernetesRuntimeInstance.Name,
-			); err == nil {
-				return errors.New("kubernetes runtime instance not deleted")
-			}
-			return nil
-		})
 	}
 
 	// construct deleted gcp gke kubernetes runtime instance config


### PR DESCRIPTION
Deleting a GcpGkeKubernetesRuntimeInstance previously relied on tptctl's config Delete method to block for up to 15 minutes waiting for the GKE instance to disappear, then confirm and delete the parent KubernetesRuntimeInstance. That only worked when the deletion originated from tptctl, and left the parent KRI orphaned when the GKE instance was deleted through any other path.

Move the cleanup into gkeLifecycle.OnDeleteConfirmed, which runs once the GCP cluster destroy actually completes. It looks up the parent KRI and triggers its deletion only when one is still present and not already scheduled for deletion; a not-found KRI or an in-progress deletion is treated as a no-op, since the normal KRI deletion flow removes the parent before the GKE destroy finishes.

Removes the corresponding wait-and-delete block from GcpGkeKubernetesRuntimeInstanceConfig.Delete, so tptctl returns as soon as the API accepts the delete rather than polling for it.