### PR TITLE
fix: tolerate missing kinds on delete and retry transient creates

### DIFF
--- a/pkg/kube/v0/resource.go
+++ b/pkg/kube/v0/resource.go
@@ -179,6 +179,13 @@ func UpdateResource(
 
 // DeleteResource takes an unstructured object, dynamic client interface and rest
 // mapper and deletes the resource in the target Kubernetes cluster.
+//
+// A missing CRD on the target cluster, meaning no REST mapping for the
+// object's GroupKind, counts as already deleted: an unregistered kind cannot
+// have instances, so there is nothing left to remove. That matches how a
+// NotFound on the delete call itself is treated, and together they keep a
+// delete reconciler from retrying forever on a resource that has nowhere to
+// live.
 func DeleteResource(
 	kubeObject *unstructured.Unstructured,
 	kubeClient dynamic.Interface,
@@ -187,6 +194,9 @@ func DeleteResource(
 	// get the mapping for resource from kube object's group, kind
 	mapping, err := getResourceMapping(kubeObject, mapper)
 	if err != nil {
+		if meta.IsNoMatchError(errors.Unwrap(err)) || meta.IsNoMatchError(err) {
+			return nil
+		}
 		return fmt.Errorf("failed to get REST mapping for kubernetes resource: %w", err)
 	}
 

--- a/pkg/kube/v0/resource.go
+++ b/pkg/kube/v0/resource.go
@@ -134,7 +134,7 @@ func CreateResource(
 			delay *= 2
 		}
 	}
-	return nil, fmt.Errorf("failed to create kubernetes resource after %d retries:%w", createRetryAttempts, err)
+	return nil, fmt.Errorf("failed to create kubernetes resource after %d attempts:%w", createRetryAttempts, err)
 
 }
 

--- a/pkg/kube/v0/resource.go
+++ b/pkg/kube/v0/resource.go
@@ -238,7 +238,7 @@ func DeleteResource(
 	// get the mapping for resource from kube object's group, kind
 	mapping, err := getResourceMapping(kubeObject, mapper)
 	if err != nil {
-		if meta.IsNoMatchError(errors.Unwrap(err)) || meta.IsNoMatchError(err) {
+		if meta.IsNoMatchError(err) {
 			return nil
 		}
 		return fmt.Errorf("failed to get REST mapping for kubernetes resource: %w", err)

--- a/pkg/kube/v0/resource.go
+++ b/pkg/kube/v0/resource.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	yamlv3 "gopkg.in/yaml.v3"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
@@ -19,6 +20,38 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/yaml"
 )
+
+// createRetryAttempts is the number of times a transient kube-apiserver
+// error (server-side timeouts, quota-evaluator timeouts) is retried before
+// the caller sees the failure. Enough tries to ride out a short apiserver
+// backpressure spike during control plane bring-up, but not so many that a
+// genuine misconfiguration hides for minutes.
+const createRetryAttempts = 5
+
+// createRetryBaseDelay backs off exponentially between retries starting
+// from this base (250ms, 500ms, 1s, 2s) so the apiserver has a chance to
+// catch up on quota evaluation before the next attempt.
+const createRetryBaseDelay = 250 * time.Millisecond
+
+// isTransientKubeError reports whether a Kubernetes API error is worth
+// retrying. Covers server-side timeouts, temporary service unavailable
+// responses, and the "Internal error occurred: resource quota evaluation
+// timed out" surface kube-apiserver emits when its quota evaluator is
+// backpressured during a burst of resource creates. Every other error
+// (AlreadyExists, NotFound, Forbidden, Invalid) is deterministic and
+// should not be retried.
+func isTransientKubeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if kubeerr.IsServerTimeout(err) || kubeerr.IsTimeout(err) || kubeerr.IsServiceUnavailable(err) || kubeerr.IsTooManyRequests(err) {
+		return true
+	}
+	if kubeerr.IsInternalError(err) && strings.Contains(err.Error(), "resource quota evaluation timed out") {
+		return true
+	}
+	return false
+}
 
 // GetResource returns a specific Kubernetes resource.  If an empty string for
 // namespace is provided, this function will search for a non-namespaced
@@ -77,20 +110,31 @@ func CreateResource(
 		return nil, fmt.Errorf("failed to get REST mapping for kubernetes resource: %w", err)
 	}
 
-	// create the kube resource
-	result, err := kubeClient.
-		Resource(mapping.Resource).
-		Namespace(kubeObject.GetNamespace()).
-		Create(context.Background(), kubeObject, kubemetav1.CreateOptions{})
-	if err != nil {
+	// create the kube resource, retrying transient apiserver errors
+	// (quota-evaluator timeout, server-side timeouts) so a busy control
+	// plane during genesis bring-up does not abort the whole install.
+	var result *unstructured.Unstructured
+	delay := createRetryBaseDelay
+	for attempt := 0; attempt < createRetryAttempts; attempt++ {
+		result, err = kubeClient.
+			Resource(mapping.Resource).
+			Namespace(kubeObject.GetNamespace()).
+			Create(context.Background(), kubeObject, kubemetav1.CreateOptions{})
+		if err == nil {
+			return result, nil
+		}
 		if kubeerr.IsAlreadyExists(err) {
 			return kubeObject, nil
-		} else {
+		}
+		if !isTransientKubeError(err) {
 			return nil, fmt.Errorf("failed to create kubernetes resource:%w", err)
 		}
+		if attempt < createRetryAttempts-1 {
+			time.Sleep(delay)
+			delay *= 2
+		}
 	}
-
-	return result, nil
+	return nil, fmt.Errorf("failed to create kubernetes resource after %d retries:%w", createRetryAttempts, err)
 
 }
 

--- a/pkg/kube/v0/resource.go
+++ b/pkg/kube/v0/resource.go
@@ -30,8 +30,9 @@ const createRetryAttempts = 5
 
 // createRetryBaseDelay backs off exponentially between retries starting
 // from this base (250ms, 500ms, 1s, 2s) so the apiserver has a chance to
-// catch up on quota evaluation before the next attempt.
-const createRetryBaseDelay = 250 * time.Millisecond
+// catch up on quota evaluation before the next attempt. It is a variable
+// rather than a constant so tests can shrink the wait.
+var createRetryBaseDelay = 250 * time.Millisecond
 
 // isTransientKubeError reports whether a Kubernetes API error is worth
 // retrying. Covers server-side timeouts, temporary service unavailable

--- a/pkg/kube/v0/resource_test.go
+++ b/pkg/kube/v0/resource_test.go
@@ -1,0 +1,82 @@
+package v0
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestDeleteResourceTreatsMissingCRDAsSuccess covers the case where the
+// target cluster has no CRD for the resource's kind: DeleteResource should
+// return nil (treat as already-deleted) so the workload-instance reconciler
+// does not hang on a resource that cannot possibly exist. The case arises
+// when a gateway controller materializes a VirtualService (gateway.solo.io)
+// and records it in the threeport database, but the CRD was never installed
+// in the target cluster.
+func TestDeleteResourceTreatsMissingCRDAsSuccess(t *testing.T) {
+	// an empty mapper knows about zero kinds, so any RESTMapping lookup
+	// returns *meta.NoKindMatchError, the same error a cluster with no CRD
+	// for the kind produces.
+	emptyMapper := meta.NewDefaultRESTMapper(nil)
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "gateway.solo.io",
+		Version: "v1",
+		Kind:    "VirtualService",
+	})
+	obj.SetName("does-not-matter")
+	obj.SetNamespace("default")
+
+	// dynamic client stays nil on purpose: DeleteResource short-circuits on
+	// the mapper miss and never dereferences the client. Should it stop
+	// short-circuiting, the call reaches the client, panics on nil, and this
+	// test fails loudly instead of appearing to pass.
+	err := DeleteResource(obj, nil, emptyMapper)
+	if err != nil {
+		t.Fatalf("DeleteResource with missing-CRD kind: got err %v, want nil", err)
+	}
+}
+
+// TestDeleteResourceForwardsOtherMapperErrors covers the negative case: a
+// mapper error that is NOT a "no match for kind" (e.g. a wrapped error
+// with a different underlying cause) should still surface as an error so
+// callers aren't silently masked from unrelated failures.
+func TestDeleteResourceForwardsOtherMapperErrors(t *testing.T) {
+	// wrap a non-NoMatch error in a mapper so getResourceMapping returns it
+	// via the normal path
+	mapper := &errMapper{err: errOtherMapperFailure}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "Deployment",
+	})
+
+	err := DeleteResource(obj, nil, mapper)
+	if err == nil {
+		t.Fatalf("DeleteResource with non-NoMatch mapper error: got nil, want error")
+	}
+}
+
+// errOtherMapperFailure is a distinct error value we can check for by identity.
+var errOtherMapperFailure = &distinctErr{msg: "some other mapper failure"}
+
+type distinctErr struct{ msg string }
+
+func (e *distinctErr) Error() string { return e.msg }
+
+// errMapper is a minimal RESTMapper that always returns a fixed error on
+// RESTMapping. All other methods are unimplemented (they return zero
+// values / nils) because DeleteResource only calls RESTMapping.
+type errMapper struct {
+	meta.RESTMapper
+	err error
+}
+
+func (m *errMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	return nil, m.err
+}

--- a/pkg/kube/v0/resource_test.go
+++ b/pkg/kube/v0/resource_test.go
@@ -1,11 +1,19 @@
 package v0
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
+	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	kubemetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/dynamic"
 )
 
 // TestDeleteResourceTreatsMissingCRDAsSuccess covers the case where the
@@ -18,7 +26,8 @@ import (
 func TestDeleteResourceTreatsMissingCRDAsSuccess(t *testing.T) {
 	// an empty mapper knows about zero kinds, so any RESTMapping lookup
 	// returns *meta.NoKindMatchError, the same error a cluster with no CRD
-	// for the kind produces.
+	// for the kind produces. getResourceMapping wraps that error before
+	// DeleteResource inspects it, so this also covers the wrapped case.
 	emptyMapper := meta.NewDefaultRESTMapper(nil)
 
 	obj := &unstructured.Unstructured{}
@@ -60,6 +69,300 @@ func TestDeleteResourceForwardsOtherMapperErrors(t *testing.T) {
 	if err == nil {
 		t.Fatalf("DeleteResource with non-NoMatch mapper error: got nil, want error")
 	}
+}
+
+// TestIsTransientKubeError covers which apiserver responses CreateResource
+// is willing to retry. The transient cases all mean the server is behind
+// rather than the request being wrong; the deterministic cases mean the
+// request will fail the same way no matter how many times it is sent.
+func TestIsTransientKubeError(t *testing.T) {
+	deployments := schema.GroupResource{Group: "apps", Resource: "deployments"}
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "server timeout",
+			err:  kubeerr.NewServerTimeout(deployments, "create", 1),
+			want: true,
+		},
+		{
+			name: "request timeout",
+			err:  kubeerr.NewTimeoutError("request timed out", 1),
+			want: true,
+		},
+		{
+			name: "service unavailable",
+			err:  kubeerr.NewServiceUnavailable("no backends available"),
+			want: true,
+		},
+		{
+			name: "too many requests",
+			err:  kubeerr.NewTooManyRequestsError("slow down"),
+			want: true,
+		},
+		{
+			name: "quota evaluator timeout",
+			err:  kubeerr.NewInternalError(errors.New("resource quota evaluation timed out")),
+			want: true,
+		},
+		{
+			name: "internal error with an unrelated cause",
+			err:  kubeerr.NewInternalError(errors.New("something else went wrong")),
+			want: false,
+		},
+		{
+			name: "already exists",
+			err:  kubeerr.NewAlreadyExists(deployments, "my-app"),
+			want: false,
+		},
+		{
+			name: "not found",
+			err:  kubeerr.NewNotFound(deployments, "my-app"),
+			want: false,
+		},
+		{
+			name: "forbidden",
+			err:  kubeerr.NewForbidden(deployments, "my-app", errors.New("not allowed")),
+			want: false,
+		},
+		{
+			name: "invalid",
+			err:  kubeerr.NewInvalid(schema.GroupKind{Group: "apps", Kind: "Deployment"}, "my-app", field.ErrorList{}),
+			want: false,
+		},
+		{
+			name: "error that did not come from the kubernetes API",
+			err:  errors.New("dial tcp: connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTransientKubeError(tc.err); got != tc.want {
+				t.Fatalf("isTransientKubeError(%v): got %t, want %t", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCreateResourceRetriesUntilTransientErrorClears covers the case the
+// retry loop exists for: an apiserver under load rejects the first
+// attempts with a quota evaluator timeout, then accepts the resource once
+// it catches up. CreateResource should keep trying and return the created
+// object rather than failing the install.
+func TestCreateResourceRetriesUntilTransientErrorClears(t *testing.T) {
+	shrinkCreateRetryDelay(t)
+
+	client := &stubDynamicClient{
+		resourceClient: &stubResourceClient{
+			results: []stubCreateResult{
+				{err: kubeerr.NewInternalError(errors.New("resource quota evaluation timed out"))},
+				{err: kubeerr.NewServerTimeout(schema.GroupResource{Group: "apps", Resource: "deployments"}, "create", 1)},
+				{object: testDeployment()},
+			},
+		},
+	}
+
+	result, err := CreateResource(testDeployment(), client, testDeploymentMapper())
+	if err != nil {
+		t.Fatalf("CreateResource with two transient failures: got err %v, want nil", err)
+	}
+	if result == nil {
+		t.Fatal("CreateResource with two transient failures: got nil object, want the created resource")
+	}
+	if client.resourceClient.attempts != 3 {
+		t.Fatalf("CreateResource with two transient failures: got %d attempts, want 3", client.resourceClient.attempts)
+	}
+}
+
+// TestCreateResourceGivesUpOnPersistentTransientError covers the ceiling on
+// retries: an apiserver that never recovers gets a bounded number of
+// attempts, and the caller sees the last error rather than the call
+// blocking indefinitely.
+func TestCreateResourceGivesUpOnPersistentTransientError(t *testing.T) {
+	shrinkCreateRetryDelay(t)
+
+	client := &stubDynamicClient{
+		resourceClient: &stubResourceClient{
+			alwaysErr: kubeerr.NewInternalError(errors.New("resource quota evaluation timed out")),
+		},
+	}
+
+	_, err := CreateResource(testDeployment(), client, testDeploymentMapper())
+	if err == nil {
+		t.Fatal("CreateResource against an apiserver that never recovers: got nil, want error")
+	}
+	if !strings.Contains(err.Error(), "resource quota evaluation timed out") {
+		t.Fatalf("CreateResource against an apiserver that never recovers: error %q does not carry the apiserver's message", err)
+	}
+	if client.resourceClient.attempts != createRetryAttempts {
+		t.Fatalf(
+			"CreateResource against an apiserver that never recovers: got %d attempts, want %d",
+			client.resourceClient.attempts, createRetryAttempts,
+		)
+	}
+}
+
+// TestCreateResourceDoesNotRetryDeterministicErrors covers the errors that
+// mean the request itself is wrong. Sending them again produces the same
+// answer, so CreateResource must return after a single attempt instead of
+// spending the backoff on a foregone conclusion.
+func TestCreateResourceDoesNotRetryDeterministicErrors(t *testing.T) {
+	deployments := schema.GroupResource{Group: "apps", Resource: "deployments"}
+
+	cases := []struct {
+		name    string
+		err     error
+		wantErr bool
+	}{
+		{
+			name:    "invalid",
+			err:     kubeerr.NewInvalid(schema.GroupKind{Group: "apps", Kind: "Deployment"}, "my-app", field.ErrorList{}),
+			wantErr: true,
+		},
+		{
+			name:    "forbidden",
+			err:     kubeerr.NewForbidden(deployments, "my-app", errors.New("not allowed")),
+			wantErr: true,
+		},
+		{
+			name:    "not found",
+			err:     kubeerr.NewNotFound(deployments, "my-app"),
+			wantErr: true,
+		},
+		{
+			// an existing resource is the one deterministic response
+			// CreateResource reports as success, since the caller's
+			// intent is already satisfied.
+			name:    "already exists",
+			err:     kubeerr.NewAlreadyExists(deployments, "my-app"),
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			shrinkCreateRetryDelay(t)
+
+			client := &stubDynamicClient{
+				resourceClient: &stubResourceClient{alwaysErr: tc.err},
+			}
+
+			_, err := CreateResource(testDeployment(), client, testDeploymentMapper())
+			if tc.wantErr && err == nil {
+				t.Fatalf("CreateResource with a %s response: got nil, want error", tc.name)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("CreateResource with a %s response: got err %v, want nil", tc.name, err)
+			}
+			if client.resourceClient.attempts != 1 {
+				t.Fatalf(
+					"CreateResource with a %s response: got %d attempts, want 1",
+					tc.name, client.resourceClient.attempts,
+				)
+			}
+		})
+	}
+}
+
+// shrinkCreateRetryDelay drops the backoff between create attempts to
+// something a test can wait out, and restores the production value when the
+// test finishes.
+func shrinkCreateRetryDelay(t *testing.T) {
+	t.Helper()
+
+	original := createRetryBaseDelay
+	createRetryBaseDelay = time.Millisecond
+	t.Cleanup(func() { createRetryBaseDelay = original })
+}
+
+// testDeployment returns a minimal deployment for the create path to send.
+func testDeployment() *unstructured.Unstructured {
+	deployment := &unstructured.Unstructured{}
+	deployment.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "Deployment",
+	})
+	deployment.SetName("my-app")
+	deployment.SetNamespace("my-app-namespace")
+
+	return deployment
+}
+
+// testDeploymentMapper returns a mapper that resolves the Deployment kind,
+// the only kind the create path tests send.
+func testDeploymentMapper() meta.RESTMapper {
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: "apps", Version: "v1"}})
+	mapper.Add(
+		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+		meta.RESTScopeNamespace,
+	)
+
+	return mapper
+}
+
+// stubCreateResult is what the stub client hands back for one create call.
+type stubCreateResult struct {
+	object *unstructured.Unstructured
+	err    error
+}
+
+// stubDynamicClient hands every resource lookup the same stub resource
+// client so a test can count create attempts. The embedded interface is
+// unimplemented on purpose: any method the create path is not expected to
+// call panics rather than quietly returning a zero value.
+type stubDynamicClient struct {
+	dynamic.Interface
+	resourceClient *stubResourceClient
+}
+
+func (c *stubDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return c.resourceClient
+}
+
+// stubResourceClient answers create calls from a scripted list of results,
+// or with the same error every time when alwaysErr is set, and records how
+// many attempts it saw.
+type stubResourceClient struct {
+	dynamic.NamespaceableResourceInterface
+	results   []stubCreateResult
+	alwaysErr error
+	attempts  int
+}
+
+func (r *stubResourceClient) Namespace(namespace string) dynamic.ResourceInterface {
+	return r
+}
+
+func (r *stubResourceClient) Create(
+	ctx context.Context,
+	object *unstructured.Unstructured,
+	options kubemetav1.CreateOptions,
+	subresources ...string,
+) (*unstructured.Unstructured, error) {
+	r.attempts++
+
+	if r.alwaysErr != nil {
+		return nil, r.alwaysErr
+	}
+	if len(r.results) == 0 {
+		return nil, errors.New("stub resource client ran out of scripted results")
+	}
+
+	result := r.results[0]
+	r.results = r.results[1:]
+
+	return result.object, result.err
 }
 
 // errOtherMapperFailure is a distinct error value we can check for by identity.


### PR DESCRIPTION
Lets a workload delete finish when the resource's kind is absent from the target cluster, and stops a single transient kube-apiserver response from aborting a control plane install.

`DeleteResource()` starts by asking the cluster's `RESTMapper` for the object's group and kind. When the kind is not registered the mapper returns a no-match error, which the function reported as a failure, so the workload delete reconciler requeued, asked for the same mapping, got the same answer, and never finished. It now treats an unmappable kind as already deleted, matching how a `NotFound` on the delete call itself is handled. `meta.IsNoMatchError()` matches through the `%w` wrap that `getResourceMapping()` adds, so one check covers it. Every other mapping error still surfaces.

`CreateResource()` made one attempt and returned whatever came back. During control plane bring-up the installer creates hundreds of resources back to back, and a loaded apiserver answers some of them with a server-side timeout or `Internal error occurred: resource quota evaluation timed out`, which means the server is behind rather than the request being wrong. It now makes five attempts, backing off 250ms, 500ms, 1s and 2s between them. `isTransientKubeError()` decides what qualifies; deterministic responses such as already-exists, not-found, forbidden and invalid still return immediately.

The missing-kind tolerance is confined to the delete path on purpose. A create against an unregistered kind is a real misconfiguration, and swallowing it would report a resource reconciled when nothing reached the cluster. `CreateOrUpdateResource()` and `UpdateResource()` keep their single-attempt behavior, so the same backpressure can still fail a workload update.

Both halves are covered. `TestDeleteResourceTreatsMissingCRDAsSuccess` sends an unmappable kind through the same wrap the production path produces, and `TestDeleteResourceForwardsOtherMapperErrors` holds the line that every other mapping error still reaches the caller. `TestIsTransientKubeError` pins which apiserver responses qualify for a retry across twelve cases. `TestCreateResourceRetriesUntilTransientErrorClears` and `TestCreateResourceGivesUpOnPersistentTransientError` cover the loop's two exits, and `TestCreateResourceDoesNotRetryDeterministicErrors` requires that an invalid, forbidden, not-found or already-exists response returns after a single attempt. The backoff base is a variable so those tests do not wait out the real delays.
