### PR TITLE
fix: grant control-plane-controller cluster-admin for provisioning

### DIFF
--- a/internal/control-plane/v0_control_plane_instance.go
+++ b/internal/control-plane/v0_control_plane_instance.go
@@ -411,7 +411,7 @@ func v0ControlPlaneInstanceCreated(
 		encryptionKey,
 		dbCreds,
 	); err != nil {
-		return 0, fmt.Errorf("failed to install threeport control plane dependencies")
+		return 0, fmt.Errorf("failed to install threeport control plane dependencies: %w", err)
 	}
 
 	// install the API
@@ -423,10 +423,12 @@ func v0ControlPlaneInstanceCreated(
 		return 0, fmt.Errorf("failed to install threeport API server: %w", err)
 	}
 
-	// for cloud providers, get the load balancer endpoint so the genesis
-	// reconciler can reach the child API across clusters
+	// for cross-cluster deployments, get the load balancer endpoint so the
+	// genesis reconciler can reach the child API across clusters. Same-cluster
+	// deployments use ClusterIP (see RestApiLoadBalancer above) and keep the
+	// in-cluster DNS endpoint already set above.
 	var lbEndpoint string
-	if *kubernetesRuntimeDefinition.InfraProvider != v0.KubernetesRuntimeInfraProviderKind {
+	if cpi.Opts.RestApiLoadBalancer {
 		lbEndpoint, err = cpi.GetThreeportAPIEndpoint(dynamicKubeClient, *mapper)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get threeport API load balancer endpoint: %w", err)

--- a/pkg/sdk/v0/config.go
+++ b/pkg/sdk/v0/config.go
@@ -78,8 +78,32 @@ type ApiObjectGroup struct {
 	// group's controller image. Empty means use the default `release` target.
 	DockerfileTarget string
 
+	// ControllerStartupHook, if set, causes the generated controller's main()
+	// to call the given no-arg, error-returning function once at startup
+	// (after logging is configured, before waiting for the API server to
+	// become reachable). Lets a downstream module run custom initialization
+	// (e.g. loading module-specific config) without hand-editing generated
+	// code. A returned error is logged but does not stop the controller from
+	// starting.
+	ControllerStartupHook *ControllerStartupHook
+
 	// List of api objects under the object group.
 	Objects []*ApiObject
+}
+
+// ControllerStartupHook configures a function to call once at controller
+// startup. See ApiObjectGroup.ControllerStartupHook.
+type ControllerStartupHook struct {
+	// PackagePath is the fully-qualified Go import path of the package
+	// containing FuncName.
+	PackagePath string
+
+	// FuncName is the name of the function to call. It must have the
+	// signature `func() error`.
+	FuncName string
+
+	// ErrorMessage is logged if the function returns an error.
+	ErrorMessage string
 }
 
 // ApiObject contains the attributes needed to manage a threeport api object.

--- a/pkg/sdk/v0/gen/cmd/controller/main.go
+++ b/pkg/sdk/v0/gen/cmd/controller/main.go
@@ -196,6 +196,8 @@ func GenControllerMain(gen *gen.Generator, sdkConfig *sdk.SdkConfig) error {
 					),
 				),
 
+				GenControllerStartupHook(objGroup),
+
 				Line().Comment("wait for API server to be reachable before proceeding"),
 				Qual(
 					"github.com/threeport/threeport/pkg/util/v0",
@@ -549,4 +551,21 @@ func ConfigurePullSubscription(
 	g.Id("ready").Op(":=").Op("&").Qual("sync/atomic", "Bool").Values()
 	g.Id("ready").Dot("Store").Call(Lit(true))
 	g.Id("readyFlags").Op("=").Append(Id("readyFlags"), Id("ready"))
+}
+
+// GenControllerStartupHook generates a call to the object group's configured
+// ControllerStartupHook, if any, logging (but not failing on) an error.
+// Returns an empty statement if no hook is configured for this object group.
+func GenControllerStartupHook(objGroup gen.ApiObjectGroup) jen.Code {
+	hook := objGroup.ControllerStartupHook
+	if hook == nil {
+		return Null()
+	}
+
+	return If(
+		Err().Op(":=").Qual(hook.PackagePath, hook.FuncName).Call(),
+		Err().Op("!=").Nil(),
+	).Block(
+		Id("log").Dot("Error").Call(Id("err"), Lit(hook.ErrorMessage)),
+	)
 }

--- a/pkg/sdk/v0/gen/generator.go
+++ b/pkg/sdk/v0/gen/generator.go
@@ -100,6 +100,11 @@ type ApiObjectGroup struct {
 	// group's controller image. Empty means use the default `release` target.
 	DockerfileTarget string
 
+	// ControllerStartupHook, if set, causes the generated controller's main()
+	// to call the given function once at startup. See
+	// sdk.ApiObjectGroup.ControllerStartupHook.
+	ControllerStartupHook *sdk.ControllerStartupHook
+
 	// List of API object names that are reconciled by a controller.
 	ReconciledApiObjectNames []string
 
@@ -697,6 +702,7 @@ func (g *Generator) New(sdkConfig *sdk.SdkConfig) error {
 				ControllerDomain:         strcase.ToCamel(sdkutil.FilenameSansExt(filename)),
 				ControllerDomainLower:    strcase.ToLowerCamel(sdkutil.FilenameSansExt(filename)),
 				DockerfileTarget:         apiObjectGroup.DockerfileTarget,
+				ControllerStartupHook:    apiObjectGroup.ControllerStartupHook,
 				ApiObjects:               apiObjects,
 				ReconciledApiObjectNames: reconcilerModels,
 				TptctlModels:             tptctlModels,

--- a/pkg/threeport-installer/v0/components.go
+++ b/pkg/threeport-installer/v0/components.go
@@ -538,7 +538,7 @@ func (cpi *ControlPlaneInstaller) InstallThreeportControllers(
 				"apiVersion": "rbac.authorization.k8s.io/v1",
 				"kind":       "ClusterRoleBinding",
 				"metadata": map[string]interface{}{
-					"name": fmt.Sprintf("%s-threeportworkloads", controller.ServiceAccountName),
+					"name": fmt.Sprintf("%s-%s-threeportworkloads", cpi.Opts.Namespace, controller.ServiceAccountName),
 				},
 				"roleRef": map[string]interface{}{
 					"apiGroup": "rbac.authorization.k8s.io",
@@ -584,7 +584,7 @@ func (cpi *ControlPlaneInstaller) InstallThreeportControllers(
 					"apiVersion": "rbac.authorization.k8s.io/v1",
 					"kind":       "ClusterRoleBinding",
 					"metadata": map[string]interface{}{
-						"name": fmt.Sprintf("%s-cluster-admin", controller.ServiceAccountName),
+						"name": fmt.Sprintf("%s-%s-cluster-admin", cpi.Opts.Namespace, controller.ServiceAccountName),
 					},
 					"roleRef": map[string]interface{}{
 						"apiGroup": "rbac.authorization.k8s.io",

--- a/pkg/threeport-installer/v0/components.go
+++ b/pkg/threeport-installer/v0/components.go
@@ -555,13 +555,16 @@ func (cpi *ControlPlaneInstaller) InstallThreeportControllers(
 		// The helm-workload-controller and kubernetes-workload-controller deploy
 		// arbitrary resources — Helm charts or raw manifests — that can define any
 		// Kubernetes resource type in any namespace (including creating
-		// namespaces). cluster-admin is required so they can manage the full
-		// lifecycle of those resources. On GKE with Workload Identity, each
-		// controller authenticates to the target cluster as its own WI principal
-		// (via per-request ADC tokens), so both the ServiceAccount and User
-		// subjects are bound.
+		// namespaces). The control-plane-controller similarly creates namespaces,
+		// secrets, service accounts, and StatefulSets/Deployments directly when
+		// bootstrapping a new child control plane. cluster-admin is required so
+		// they can manage the full lifecycle of those resources. On GKE with
+		// Workload Identity, each controller authenticates to the target cluster
+		// as its own WI principal (via per-request ADC tokens), so both the
+		// ServiceAccount and User subjects are bound.
 		if controller.Name == ThreeportHelmWorkloadControllerName ||
-			controller.Name == ThreeportKubernetesWorkloadControllerName {
+			controller.Name == ThreeportKubernetesWorkloadControllerName ||
+			controller.Name == ThreeportControlPlaneControllerName {
 			clusterAdminSubjects := []interface{}{
 				map[string]interface{}{
 					"kind":      "ServiceAccount",


### PR DESCRIPTION
## Summary

Fixes several issues that prevented `control-plane-controller` from
successfully provisioning a new control plane, discovered while
testing control plane creation on a real cluster. Also adds a small
SDK extension point needed by a downstream module fix.

- **Grant `control-plane-controller` cluster-admin.** It directly
  creates namespaces, secrets, service accounts, and
  StatefulSets/Deployments when bootstrapping a new control plane —
  the same category of work `helm-workload-controller` and
  `kubernetes-workload-controller` already get cluster-admin for, but
  it was left out of that grant. Without it, every control plane
  create failed with a 403 on `namespaces.create`.

- **Only wait for a load balancer endpoint when actually
  cross-cluster.** The check only tested `InfraProvider != Kind`,
  which is true for every cloud provider regardless of whether the
  new control plane shares a cluster with its parent. Same-cluster
  deployments use `ClusterIP` (see `RestApiLoadBalancer`) and were
  stuck waiting 60 seconds per attempt for an ingress that could never
  appear.

- **Namespace-qualify the `cluster-admin`/`threeportworkloads`
  `ClusterRoleBinding` names.** They were named only after the
  controller's service account (e.g.
  `control-plane-controller-cluster-admin`), with no namespace or
  control-plane qualifier. Since `ClusterRoleBinding`s are
  cluster-scoped, provisioning a *child* control plane's own copy of
  these controllers overwrote the *root* control plane's identical
  binding, silently revoking its permissions mid-reconcile.

- **Wrap the real error instead of discarding it** when
  `InstallThreeportControlPlaneDependencies` fails. Previously this
  returned a generic, no-detail error, which made every failure above
  much harder to diagnose than necessary.

- **Add a `ControllerStartupHook` SDK extension point.** Lets a
  downstream module configure a generated controller's `main()` to
  call a custom initialization function at startup (e.g. loading
  module-specific config), without hand-editing generated code. Used
  by a follow-up fix in `qleet-threeport-module`.

## Testing

All fixes verified end-to-end on a live cluster: a freshly created
control plane (same-cluster deployment) now provisions and reconciles
successfully, where it previously failed at each of the above steps
in sequence.