### PR TITLE
docs: replace make with mage in dev quickstart guide

### DIFF
--- a/docs/dev/quickstart.md
+++ b/docs/dev/quickstart.md
@@ -15,8 +15,7 @@ operations:
   messages used by the control plane.
 * [mage](https://magefile.org/) for using mage targets.
 
-First, install the `tptctl` CLI so it's available on your `PATH`.  There are
-two ways to do this:
+First, install the `tptctl` CLI.  There are two ways to do this:
 
 * Build it from this branch's source with mage.  This is the recommended way
   for development, since it guarantees `tptctl` matches the code you're
@@ -25,6 +24,17 @@ two ways to do this:
   ```bash
   mage install:tptctl
   ```
+
+  This copies the binary to `$GOBIN`, or `$(go env GOPATH)/bin` if `$GOBIN`
+  is unset.  Make sure that directory is on your `PATH` - if `tptctl version`
+  fails with "command not found" after this step, add it:
+
+  ```bash
+  export PATH="$PATH:$(go env GOPATH)/bin"
+  ```
+
+  Add that line to your shell profile (e.g. `~/.zshrc` or `~/.bashrc`) to
+  persist it across sessions.
 
 * Or install a pre-built release binary by following the [Install tptctl
   guide](../docs/install/install-tptctl.md).  Note this installs the latest

--- a/docs/dev/quickstart.md
+++ b/docs/dev/quickstart.md
@@ -15,32 +15,27 @@ operations:
   messages used by the control plane.
 * [mage](https://magefile.org/) for using mage targets.
 
-First, install the `tptctl` CLI.  There are two ways to do this:
+Note: run every command in this guide, including all mage targets, from the
+root of this repo.
 
-* Build it from this branch's source with mage.  This is the recommended way
-  for development, since it guarantees `tptctl` matches the code you're
-  working on:
+First, install the `tptctl` CLI by building it from this branch's source with
+mage.  This ensures `tptctl` matches the code you're working on:
 
-  ```bash
-  mage install:tptctl
-  ```
+```bash
+mage install:tptctl
+```
 
-  This prints the exact path it installed to, e.g. `tptctl binary installed
-  and available at /home/you/go/bin/tptctl`.  If `tptctl version` fails with
-  "command not found" afterward, that directory isn't on your `PATH` - add it,
-  using the directory from your own command's output (not copied verbatim):
+This prints the exact path it installed to, e.g. `tptctl binary installed
+and available at /home/you/go/bin/tptctl`.  If `tptctl version` fails with
+"command not found" afterward, that directory isn't on your `PATH` - add it,
+using the directory from your own command's output (not copied verbatim):
 
-  ```bash
-  export PATH="$PATH:/home/you/go/bin"
-  ```
+```bash
+export PATH="$PATH:/home/you/go/bin"
+```
 
-  Add that line to your shell profile (e.g. `~/.zshrc` or `~/.bashrc`) to
-  persist it across sessions.
-
-* Or install a pre-built release binary by following the [Install tptctl
-  guide](../docs/install/install-tptctl.md).  Note this installs the latest
-  *released* version, which may not match the in-development code on this
-  branch.
+Add that line to your shell profile (e.g. `~/.zshrc` or `~/.bashrc`) to
+persist it across sessions.
 
 Create a local container registry.  This mage target runs a local docker
 container to serve as the container registry, so we don't have to wait for
@@ -57,29 +52,16 @@ mage build:allImagesDev
 ```
 
 Install Threeport from the newly built images.  `--name` is an arbitrary name
-you choose for this control plane instance:
+you choose for this control plane instance.  `--control-plane-image-tag` must
+match the tag `mage build:allImagesDev` just pushed to the registry - that tag
+comes from `internal/version/version.txt` (the same file
+`mage build:allImagesDev` reads via `version.GetVersion()`), so rather than
+hardcoding a version that will go stale as this branch is synced with new
+releases, read it from that file.  `--control-plane-image-namespace` is always
+`localhost:5001` for this local-registry workflow:
 
 ```bash
-tptctl up \
-  --name dev-0 \
-  --provider kind \
-  --auth-enabled=false \
-  --local-registry \
-  --control-plane-image-namespace localhost:5001 \
-  --control-plane-image-tag v0.7.0-dev
-```
-
-The `--control-plane-image-tag` must match the tag `mage build:allImagesDev`
-just pushed to the registry.  That tag comes from `internal/version/version.txt`
-(the same file `mage build:allImagesDev` reads via `version.GetVersion()`), so
-rather than hardcoding a version that will go stale as this branch is synced
-with new releases, read it from that file.  `--control-plane-image-namespace`
-is always `localhost:5001` for this local-registry workflow.  Here's the same
-command with everything captured as variables, so it stays reusable and never
-goes stale:
-
-```bash
-CONTROL_PLANE_NAME=<name>
+CONTROL_PLANE_NAME=dev-0  # an arbitrary name for the Threeport installation
 CONTROL_PLANE_IMAGE_NAMESPACE=localhost:5001
 CONTROL_PLANE_IMAGE_TAG=$(cat internal/version/version.txt)
 
@@ -103,12 +85,6 @@ curl localhost/swagger/index.html
 ```
 
 Uninstall the local dev control plane:
-
-```bash
-tptctl down --name dev-0
-```
-
-Or, if you used the variable form above:
 
 ```bash
 tptctl down --name "$CONTROL_PLANE_NAME"

--- a/docs/dev/quickstart.md
+++ b/docs/dev/quickstart.md
@@ -15,28 +15,97 @@ operations:
   messages used by the control plane.
 * [mage](https://magefile.org/) for using mage targets.
 
-Spin up a local dev control plane:
+First, install the `tptctl` CLI so it's available on your `PATH`.  There are
+two ways to do this:
+
+* Build it from this branch's source with mage.  This is the recommended way
+  for development, since it guarantees `tptctl` matches the code you're
+  working on:
+
+  ```bash
+  mage install:tptctl
+  ```
+
+* Or install a pre-built release binary by following the [Install tptctl
+  guide](../docs/install/install-tptctl.md).  Note this installs the latest
+  *released* version, which may not match the in-development code on this
+  branch.
+
+Create a local container registry.  This mage target runs a local docker
+container to serve as the container registry, so we don't have to wait for
+images to be pushed to - and pulled from - a remote registry.
 
 ```bash
-make dev-up
+mage dev:localRegistryUp
+```
+
+Build all Threeport control plane images and push them to the local registry:
+
+```bash
+mage build:allImagesDev
+```
+
+Install Threeport from the newly built images.  `--name` is an arbitrary name
+you choose for this control plane instance:
+
+```bash
+tptctl up \
+  --name dev-0 \
+  --provider kind \
+  --auth-enabled=false \
+  --local-registry \
+  --control-plane-image-namespace localhost:5001 \
+  --control-plane-image-tag v0.7.0-dev
+```
+
+The `--control-plane-image-tag` must match the tag `mage build:allImagesDev`
+just pushed to the registry.  That tag comes from `internal/version/version.txt`
+(the same file `mage build:allImagesDev` reads via `version.GetVersion()`), so
+rather than hardcoding a version that will go stale as this branch is synced
+with new releases, read it from that file.  `--control-plane-image-namespace`
+is always `localhost:5001` for this local-registry workflow.  Here's the same
+command with everything captured as variables, so it stays reusable and never
+goes stale:
+
+```bash
+CONTROL_PLANE_NAME=<name>
+CONTROL_PLANE_IMAGE_NAMESPACE=localhost:5001
+CONTROL_PLANE_IMAGE_TAG=$(cat internal/version/version.txt)
+
+tptctl up \
+  --name "$CONTROL_PLANE_NAME" \
+  --provider kind \
+  --auth-enabled=false \
+  --local-registry \
+  --control-plane-image-namespace "$CONTROL_PLANE_IMAGE_NAMESPACE" \
+  --control-plane-image-tag "$CONTROL_PLANE_IMAGE_TAG"
 ```
 
 This will start a local kind cluster and install the control plane.  You can now
 make calls to the API server.
 
-Note: The development environment is created using tptdev tool.  The tptdev
-tool references files in the source code so assumes, by default that it is being
-run from the root of this repo.
-
-Call the API:
+Call the API.  Note this is a different port than the local container registry
+(`localhost:5001`) - the API is served on the default http port:
 
 ```bash
 curl localhost/swagger/index.html
 ```
 
-Delete a local dev control plane:
+Uninstall the local dev control plane:
 
 ```bash
-make dev-down
+tptctl down --name dev-0
+```
+
+Or, if you used the variable form above:
+
+```bash
+tptctl down --name "$CONTROL_PLANE_NAME"
+```
+
+Stop and remove the local container registry:
+
+```bash
+mage dev:localRegistryDown
 ```
 

--- a/docs/dev/quickstart.md
+++ b/docs/dev/quickstart.md
@@ -18,8 +18,11 @@ operations:
 Note: run every command in this guide, including all mage targets, from the
 root of this repo.
 
-First, install the `tptctl` CLI by building it from this branch's source with
-mage.  This ensures `tptctl` matches the code you're working on:
+First, check out the branch you'll be working from - generally the latest
+release branch (currently `0.7`), or a feature branch checked out from it if
+you're working on a contribution.  Then install the `tptctl` CLI by building
+it from that branch's source with mage.  This ensures `tptctl` matches the
+code you're working on:
 
 ```bash
 mage install:tptctl

--- a/docs/dev/quickstart.md
+++ b/docs/dev/quickstart.md
@@ -25,12 +25,13 @@ First, install the `tptctl` CLI.  There are two ways to do this:
   mage install:tptctl
   ```
 
-  This copies the binary to `$GOBIN`, or `$(go env GOPATH)/bin` if `$GOBIN`
-  is unset.  Make sure that directory is on your `PATH` - if `tptctl version`
-  fails with "command not found" after this step, add it:
+  This prints the exact path it installed to, e.g. `tptctl binary installed
+  and available at /home/you/go/bin/tptctl`.  If `tptctl version` fails with
+  "command not found" afterward, that directory isn't on your `PATH` - add it,
+  using the directory from your own command's output (not copied verbatim):
 
   ```bash
-  export PATH="$PATH:${GOBIN:-$(go env GOPATH)/bin}"
+  export PATH="$PATH:/home/you/go/bin"
   ```
 
   Add that line to your shell profile (e.g. `~/.zshrc` or `~/.bashrc`) to

--- a/docs/dev/quickstart.md
+++ b/docs/dev/quickstart.md
@@ -30,7 +30,7 @@ First, install the `tptctl` CLI.  There are two ways to do this:
   fails with "command not found" after this step, add it:
 
   ```bash
-  export PATH="$PATH:$(go env GOPATH)/bin"
+  export PATH="$PATH:${GOBIN:-$(go env GOPATH)/bin}"
   ```
 
   Add that line to your shell profile (e.g. `~/.zshrc` or `~/.bashrc`) to


### PR DESCRIPTION
Updates `docs/dev/quickstart.md` to replace the removed `make dev-up`/`make dev-down` workflow with the current mage + tptctl flow, adds a step to install `tptctl` first (build from source or via the release guide), adds `--auth-enabled=false` to the `tptctl up` example so the documented `curl localhost/swagger/index.html` actually works, and gives both a literal copy-pasteable example and a variable-driven one that reads the image tag from `internal/version/version.txt` so it stays current as this branch is synced with new releases.