### PR TITLE
fix: use the supplied kubeconfig when connecting the local registry

### DIFF
--- a/cmd/tptdev/cmd/build.go
+++ b/cmd/tptdev/cmd/build.go
@@ -302,6 +302,10 @@ func init() {
 		&noCache,
 		"no-cache", false, "Build go binaries without the local go cache (passes -a to go build).",
 	)
+	buildCmd.Flags().StringVar(
+		&kubeconfigPath,
+		"kubeconfig", "", "Kubeconfig file to use (default is $KUBECONFIG, then ~/.kube/config).",
+	)
 }
 
 // detectAuthEnabled checks the running API server deployment to determine if

--- a/cmd/tptdev/cmd/debug.go
+++ b/cmd/tptdev/cmd/debug.go
@@ -16,6 +16,11 @@ import (
 
 var disable bool
 var debugComponentNames string
+
+// kubeconfigPath backs the --kubeconfig flag on both the debug and the build
+// commands. Each has to register the flag itself: cobra binds flags per
+// command, so a command that reads this without registering it always sees the
+// empty string and silently falls back to the default kubeconfig.
 var kubeconfigPath string
 var controlPlaneNamespace string
 

--- a/pkg/cli/v0/provider_kind.go
+++ b/pkg/cli/v0/provider_kind.go
@@ -90,6 +90,7 @@ func DeployKindInfra(
 	if cpi.Opts.LocalRegistry {
 		if err := tptdev.ConnectLocalRegistry(
 			provider.ThreeportRuntimeName(cpi.Opts.ControlPlaneName),
+			cpi.Opts.KubeconfigPath,
 		); err != nil {
 			return uninstaller.cleanOnCreateError("failed to connect local container registry to Threeport control plane cluster", err)
 		}

--- a/pkg/threeport-installer/v0/tptdev/registry.go
+++ b/pkg/threeport-installer/v0/tptdev/registry.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/kind/pkg/cluster"
+
+	util "github.com/threeport/threeport/pkg/util/v0"
 )
 
 const (
@@ -88,7 +90,13 @@ func CreateLocalRegistry() error {
 }
 
 // ConnectLocalRegistry connects a local Docker container registry to a kind cluster.
-func ConnectLocalRegistry(clusterName string) error {
+//
+// kubeconfigPath is the kubeconfig the rest of the command resolved, from
+// --kind-kubeconfig or client-go's default precedence. It has to be threaded in
+// rather than resolved here: with --kind-kubeconfig pointing at a pre-existing
+// kind cluster, re-resolving would target whatever is active in the default
+// location, which may be a different cluster or none at all.
+func ConnectLocalRegistry(clusterName string, kubeconfigPath string) error {
 	ctx := context.Background()
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
@@ -128,19 +136,7 @@ func ConnectLocalRegistry(clusterName string) error {
 	}
 
 	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
-	config := `apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: local-registry-hosting
-  namespace: kube-public
-data:
-  localRegistryHosting.v1: |
-    host: "localhost:%s"
-    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"`
-
-	config = fmt.Sprintf(config, registryPort)
-
-	return applyK8sConfig(config)
+	return applyK8sConfig(kubeconfigPath)
 }
 
 // DeleteLocalRegistry stops and removes the Docker container running the local
@@ -164,12 +160,26 @@ func DeleteLocalRegistry() error {
 	return nil
 }
 
-// applyK8sConfig creates a configmap to in the Kubernetes cluster.
-func applyK8sConfig(config string) error {
-	// resolve kubeconfig via client-go's standard precedence
-	// ($KUBECONFIG, then ~/.kube/config)
-	kubeconfig := clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
-	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+// resolveKubeconfigPath returns the kubeconfig to use, falling back to
+// client-go's standard precedence ($KUBECONFIG, then ~/.kube/config) only when
+// the caller supplied nothing. A supplied path must win: resolving afresh is
+// what made --kind-kubeconfig silently ignored on the local registry step.
+func resolveKubeconfigPath(kubeconfigPath string) string {
+	if kubeconfigPath != "" {
+		return kubeconfigPath
+	}
+
+	return clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
+}
+
+// applyK8sConfig creates the local registry configmap in the Kubernetes
+// cluster the supplied kubeconfig points at.
+func applyK8sConfig(kubeconfigPath string) error {
+	kubeconfigPath = resolveKubeconfigPath(kubeconfigPath)
+
+	util.CliOutputInfo(fmt.Sprintf("applying local registry configmap using kubeconfig %s", kubeconfigPath))
+
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to generate Kubernetes REST config from kubeconfig: %w", err)
 	}

--- a/pkg/threeport-installer/v0/tptdev/registry_test.go
+++ b/pkg/threeport-installer/v0/tptdev/registry_test.go
@@ -1,0 +1,27 @@
+package tptdev
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// TestResolveKubeconfigPath covers the defect where the local registry step
+// ignored --kind-kubeconfig. The path the rest of the command resolved has to
+// win; re-resolving here sent the configmap to whatever cluster happened to be
+// active in the default kubeconfig, which with --control-plane-only against a
+// pre-existing kind cluster is a different cluster or none at all.
+func TestResolveKubeconfigPath(t *testing.T) {
+	t.Run("a supplied path is used as given", func(t *testing.T) {
+		const supplied = "/tmp/kind-cluster.kubeconfig"
+
+		assert.Equal(t, supplied, resolveKubeconfigPath(supplied))
+	})
+
+	t.Run("an empty path falls back to client-go precedence", func(t *testing.T) {
+		want := clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
+
+		assert.Equal(t, want, resolveKubeconfigPath(""))
+	})
+}

--- a/pkg/threeport-installer/v0/tptdev/registry_test.go
+++ b/pkg/threeport-installer/v0/tptdev/registry_test.go
@@ -1,9 +1,11 @@
 package tptdev
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -24,4 +26,26 @@ func TestResolveKubeconfigPath(t *testing.T) {
 
 		assert.Equal(t, want, resolveKubeconfigPath(""))
 	})
+}
+
+// TestApplyK8sConfigUsesSuppliedPath covers the seam the resolver test cannot
+// reach: that the path is actually what the REST config is built from, rather
+// than resolved again inside. Pointing at a file that does not exist is enough
+// to tell the two apart, because client-go names the file it failed to stat —
+// a version that ignored the argument would name the default kubeconfig
+// instead, or succeed against whatever cluster happens to be active.
+func TestApplyK8sConfigUsesSuppliedPath(t *testing.T) {
+	supplied := filepath.Join(t.TempDir(), "kind-cluster.kubeconfig")
+
+	err := applyK8sConfig(supplied)
+
+	require.Error(t, err, "a kubeconfig that does not exist cannot produce a client")
+	assert.Contains(
+		t, err.Error(), supplied,
+		"the error must name the supplied kubeconfig, or the path was not the one used",
+	)
+	assert.NotContains(
+		t, err.Error(), clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename(),
+		"the default kubeconfig must not be consulted when a path was supplied",
+	)
 }


### PR DESCRIPTION
Closes #493

## The reported bug

`ConnectLocalRegistry` and `applyK8sConfig` now take the kubeconfig path the
rest of the command already resolved, instead of calling
`clientcmd.NewDefaultClientConfigLoadingRules()` again. `provider_kind.go`
passes `cpi.Opts.KubeconfigPath`, which was already in scope there.

Resolution moved into `resolveKubeconfigPath`, which falls back to client-go's
precedence only when the caller supplied nothing. That matches
`GetKubeDynamicClientAndMapper` in `pkg/client/lib/v0/client.go`, which already
took a path and fell back the same way.

Behavior is unchanged when `--kind-kubeconfig` is not passed:
`genesis_control_plane.go` already defaults `KubeconfigPath` to client-go's
resolution before it reaches the provider, so the same file is used either way.

Reproduced the reported scenario in isolation. A kind cluster was created with
its kubeconfig written only to a non-default path, while the default
`~/.kube/config` had no current context — so falling back fails and using the
supplied path succeeds:

with the supplied path:  applying ... using kubeconfig .../kind-test.kubeconfig
                         configmap applied
with an empty path:      applying ... using kubeconfig ~/.kube/config
                         ERROR: no configuration has been provided

The configmap landed in the cluster the supplied kubeconfig points at.
`registry_test.go` is new and pins both branches of the resolution.

## A second instance of the same class

Sweeping for the same pattern turned up one more, in a different binary.
`cmd/tptdev/cmd/build.go` reads `kubeconfigPath`, a package-level variable whose
`--kubeconfig` flag was registered only on `DebugCmd`. cobra binds flags per
command, so `tptdev build` always saw the empty string and fell back to the
default kubeconfig with no way to point it elsewhere:

before:  tptdev build --kubeconfig <path>   ->  Error: unknown flag: --kubeconfig
after:   accepted, and listed in --help

This one bites harder than the reported bug. That client drives
`UpdateThreeportAPIDeployment` and pod restarts under `--push --restart`, so the
wrong kubeconfig restarts control plane components in the wrong cluster rather
than applying one stray configmap.

The variable is now documented with why each command reading it has to register
the flag, since the next command to use it would repeat the bug otherwise.

Say the word if you would rather this went in its own PR — it is not what #493
asks for, and the two commits split cleanly.

## Also in this change

The issue's note about logging: `applyK8sConfig` now prints which kubeconfig it
is using, which is what made the failing case above legible. It uses
`util.CliOutputInfo` rather than `cli.Info`, because `pkg/cli/v0` imports
`tptdev` and the reverse would be an import cycle.

`applyK8sConfig` took a `config string` holding a YAML document that
`ConnectLocalRegistry` built with `fmt.Sprintf` and the function never read —
it constructs the ConfigMap from structs. Both the parameter and the dead YAML
are removed.

## Verification

Build clean, unit tests green, `gofmt` unchanged from the branch point. The two
`go vet` warnings in `pkg/cli/v0/provider_eks.go` are pre-existing and untouched
by this change.
